### PR TITLE
Fix initializing state logic

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -71,22 +71,6 @@ func Set(data map[string]interface{}) {
 	}
 
 	val, ok = values.GetValue(data, "status", "conditions")
-	if !ok || val == nil {
-		if val, ok := values.GetValue(data, "metadata", "created"); ok {
-			if i, err := convert.ToTimestamp(val); err == nil {
-				if time.Unix(i/1000, 0).Add(5 * time.Second).Before(time.Now()) {
-					data["state"] = "active"
-					data["transitioning"] = "no"
-					return
-				}
-			}
-		}
-
-		data["state"] = "initializing"
-		data["transitioning"] = "yes"
-		return
-	}
-
 	var conditions []condition
 	if err := convert.ToObj(val, &conditions); err != nil {
 		// ignore error
@@ -145,25 +129,38 @@ func Set(data map[string]interface{}) {
 	}
 
 	if state == "" {
-		val, _ := values.GetValueN(data, "status", "phase").(string)
-		if val != "" {
-			state = val
-		}
-	}
+		if val, ok := values.GetValue(data, "metadata", "created"); ok {
+			if i, err := convert.ToTimestamp(val); err == nil {
+				if time.Unix(i/1000, 0).Add(5 * time.Second).Before(time.Now()) {
+					if state == "" {
+						val, _ := values.GetValueN(data, "status", "phase").(string)
+						if val != "" {
+							state = val
+						}
+					}
 
-	if state == "" {
-		val, ok := values.GetValue(data, "spec", "active")
-		if ok {
-			if convert.ToBool(val) {
-				state = "active"
-			} else {
-				state = "inactive"
+					if state == "" {
+						val, ok := values.GetValue(data, "spec", "active")
+						if ok {
+							if convert.ToBool(val) {
+								state = "active"
+							} else {
+								state = "inactive"
+							}
+						}
+					}
+
+					if state == "" {
+						state = "active"
+					}
+				}
 			}
 		}
-	}
 
-	if state == "" {
-		state = "active"
+		if state == "" {
+			state = "initializing"
+			transitioning = true
+		}
 	}
 
 	data["state"] = strings.ToLower(state)


### PR DESCRIPTION
This was found because machineDrivers have a field on spec called active, that was not being properly respected when determining state and the drivers were always showing as active.

This function contains logic to look for a phase field or an "active"
field on the spec, if the resource has one and to use those
values to determine the resource's state.

But, if the resource was older than five seconds and had no conditions,
that logic was not getting hit and the resource was just defaulting
to "active".

This change let's us check the phase and spec.active before falling
back to active or initializing.
