### PR TITLE
NodeLabels/nodeAnnotations to MachineStatus

### DIFF
--- a/apis/management.cattle.io/v3/machine_types.go
+++ b/apis/management.cattle.io/v3/machine_types.go
@@ -69,6 +69,8 @@ type MachineStatus struct {
 	NodeConfig          *RKEConfigNode       `json:"rkeNode,omitempty"`
 	SSHUser             string               `json:"sshUser,omitempty"`
 	MachineDriverConfig string               `json:"machineDriverConfig,omitempty"`
+	NodeAnnotations     map[string]string    `json:"nodeAnnotations,omitempty"`
+	NodeLabels          map[string]string    `json:"nodeLabels,omitempty"`
 }
 
 var (

--- a/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -2051,6 +2051,20 @@ func (in *MachineStatus) DeepCopyInto(out *MachineStatus) {
 			(*in).DeepCopyInto(*out)
 		}
 	}
+	if in.NodeAnnotations != nil {
+		in, out := &in.NodeAnnotations, &out.NodeAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.NodeLabels != nil {
+		in, out := &in.NodeLabels, &out.NodeLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/client/management/v3/zz_generated_machine.go
+++ b/client/management/v3/zz_generated_machine.go
@@ -23,6 +23,8 @@ const (
 	MachineFieldMachineTemplateId    = "machineTemplateId"
 	MachineFieldName                 = "name"
 	MachineFieldNamespaceId          = "namespaceId"
+	MachineFieldNodeAnnotations      = "nodeAnnotations"
+	MachineFieldNodeLabels           = "nodeLabels"
 	MachineFieldNodeName             = "nodeName"
 	MachineFieldOwnerReferences      = "ownerReferences"
 	MachineFieldPodCidr              = "podCidr"
@@ -61,6 +63,8 @@ type Machine struct {
 	MachineTemplateId    string                    `json:"machineTemplateId,omitempty"`
 	Name                 string                    `json:"name,omitempty"`
 	NamespaceId          string                    `json:"namespaceId,omitempty"`
+	NodeAnnotations      map[string]string         `json:"nodeAnnotations,omitempty"`
+	NodeLabels           map[string]string         `json:"nodeLabels,omitempty"`
 	NodeName             string                    `json:"nodeName,omitempty"`
 	OwnerReferences      []OwnerReference          `json:"ownerReferences,omitempty"`
 	PodCidr              string                    `json:"podCidr,omitempty"`

--- a/client/management/v3/zz_generated_machine_status.go
+++ b/client/management/v3/zz_generated_machine_status.go
@@ -9,6 +9,8 @@ const (
 	MachineStatusFieldIPAddress       = "ipAddress"
 	MachineStatusFieldInfo            = "info"
 	MachineStatusFieldLimits          = "limits"
+	MachineStatusFieldNodeAnnotations = "nodeAnnotations"
+	MachineStatusFieldNodeLabels      = "nodeLabels"
 	MachineStatusFieldNodeName        = "nodeName"
 	MachineStatusFieldRequested       = "requested"
 	MachineStatusFieldSSHUser         = "sshUser"
@@ -24,6 +26,8 @@ type MachineStatus struct {
 	IPAddress       string                    `json:"ipAddress,omitempty"`
 	Info            *NodeInfo                 `json:"info,omitempty"`
 	Limits          map[string]string         `json:"limits,omitempty"`
+	NodeAnnotations map[string]string         `json:"nodeAnnotations,omitempty"`
+	NodeLabels      map[string]string         `json:"nodeLabels,omitempty"`
 	NodeName        string                    `json:"nodeName,omitempty"`
 	Requested       map[string]string         `json:"requested,omitempty"`
 	SSHUser         string                    `json:"sshUser,omitempty"`


### PR DESCRIPTION
@ibuildthecloud this would be the field for storing node.labels/node.annotations on the corresponding machine object. If you are fine with the fields placement, I'll make changes to cluster-agent.