### PR TITLE
Fixed drone

### DIFF
--- a/client/project/v3/zz_generated_deployment_parallel_config.go
+++ b/client/project/v3/zz_generated_deployment_parallel_config.go
@@ -3,12 +3,12 @@ package client
 const (
 	DeploymentParallelConfigType                         = "deploymentParallelConfig"
 	DeploymentParallelConfigFieldMinReadySeconds         = "minReadySeconds"
-	DeploymentParallelConfigFieldProgressDeadlineSeconds = "processDeadlineSeconds"
+	DeploymentParallelConfigFieldProgressDeadlineSeconds = "progressDeadlineSeconds"
 	DeploymentParallelConfigFieldStartFirst              = "startFirst"
 )
 
 type DeploymentParallelConfig struct {
 	MinReadySeconds         *int64 `json:"minReadySeconds,omitempty"`
-	ProgressDeadlineSeconds *int64 `json:"processDeadlineSeconds,omitempty"`
+	ProgressDeadlineSeconds *int64 `json:"progressDeadlineSeconds,omitempty"`
 	StartFirst              *bool  `json:"startFirst,omitempty"`
 }


### PR DESCRIPTION
@ibuildthecloud I get this file changed by running `go generate` or `go build && ./types`. Not sure if this param name should get changed, or there is some bug elsewhere in go generate