### PR TITLE
 Removed defaults for rke system images + hide system images from user facing api

### DIFF
--- a/apis/management.cattle.io/v3/rke_types.go
+++ b/apis/management.cattle.io/v3/rke_types.go
@@ -38,23 +38,23 @@ type PrivateRegistry struct {
 
 type RKESystemImages struct {
 	// etcd image
-	Etcd string `yaml:"etcd" json:"etcd,omitempty" norman:"default=quay.io/coreos/etcd:v3.0.17"`
+	Etcd string `yaml:"etcd" json:"etcd,omitempty"`
 	// Alpine image
-	Alpine string `yaml:"alpine" json:"alpine,omitempty" norman:"default=alpine"`
+	Alpine string `yaml:"alpine" json:"alpine,omitempty"`
 	// rke-nginx-proxy image
-	NginxProxy string `yaml:"nginx_proxy" json:"nginxProxy,omitempty" norman:"default=rancher/rke-nginx-proxy:v0.1.1"`
+	NginxProxy string `yaml:"nginx_proxy" json:"nginxProxy,omitempty"`
 	// rke-cert-deployer image
-	CertDownloader string `yaml:"cert_downloader" json:"certDownloader,omitempty" norman:"default=rancher/rke-cert-deployer:v0.1.1"`
+	CertDownloader string `yaml:"cert_downloader" json:"certDownloader,omitempty"`
 	// rke-service-sidekick image
-	KubernetesServicesSidecar string `yaml:"kubernetes_services_sidecar" json:"kubernetesServicesSidecar,omitempty" norman:"default=rancher/rke-service-sidekick:v0.1.0"`
+	KubernetesServicesSidecar string `yaml:"kubernetes_services_sidecar" json:"kubernetesServicesSidecar,omitempty"`
 	// KubeDNS image
-	KubeDNS string `yaml:"kubedns" json:"kubedns,omitempty" norman:"default=gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5"`
+	KubeDNS string `yaml:"kubedns" json:"kubedns,omitempty"`
 	// DNSMasq image
-	DNSmasq string `yaml:"dnsmasq" json:"dnsmasq,omitempty" norman:"default=gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5"`
+	DNSmasq string `yaml:"dnsmasq" json:"dnsmasq,omitempty"`
 	// KubeDNS side car image
-	KubeDNSSidecar string `yaml:"kubedns_sidecar" json:"kubednsSidecar,omitempty" norman:"default=gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5"`
+	KubeDNSSidecar string `yaml:"kubedns_sidecar" json:"kubednsSidecar,omitempty"`
 	// KubeDNS autoscaler image
-	KubeDNSAutoscaler string `yaml:"kubedns_autoscaler" json:"kubednsAutoscaler,omitempty" norman:"default=gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0"`
+	KubeDNSAutoscaler string `yaml:"kubedns_autoscaler" json:"kubednsAutoscaler,omitempty"`
 	// Kubernetes image
 	Kubernetes string `yaml:"kubernetes" json:"kubernetes,omitempty" norman:"default=rancher/k8s:v1.8.5-rancher4"`
 	// Flannel image

--- a/apis/management.cattle.io/v3/schema/schema.go
+++ b/apis/management.cattle.io/v3/schema/schema.go
@@ -81,6 +81,9 @@ func clusterTypes(schemas *types.Schemas) *types.Schemas {
 		AddMapperForType(&Version, v3.ClusterRegistrationToken{},
 			&m.Embed{Field: "status"},
 		).
+		AddMapperForType(&Version, v3.RancherKubernetesEngineConfig{},
+			m.Drop{Field: "systemImages"},
+		).
 		MustImportAndCustomize(&Version, v3.Cluster{}, func(schema *types.Schema) {
 			schema.SubContext = "clusters"
 		}).

--- a/client/management/v3/zz_generated_rancher_kubernetes_engine_config.go
+++ b/client/management/v3/zz_generated_rancher_kubernetes_engine_config.go
@@ -12,7 +12,6 @@ const (
 	RancherKubernetesEngineConfigFieldPrivateRegistries   = "privateRegistries"
 	RancherKubernetesEngineConfigFieldSSHKeyPath          = "sshKeyPath"
 	RancherKubernetesEngineConfigFieldServices            = "services"
-	RancherKubernetesEngineConfigFieldSystemImages        = "systemImages"
 	RancherKubernetesEngineConfigFieldVersion             = "kubernetesVersion"
 )
 
@@ -27,6 +26,5 @@ type RancherKubernetesEngineConfig struct {
 	PrivateRegistries   []PrivateRegistry  `json:"privateRegistries,omitempty"`
 	SSHKeyPath          string             `json:"sshKeyPath,omitempty"`
 	Services            *RKEConfigServices `json:"services,omitempty"`
-	SystemImages        *RKESystemImages   `json:"systemImages,omitempty"`
 	Version             string             `json:"kubernetesVersion,omitempty"`
 }


### PR DESCRIPTION
system images are generated and passed to rke based on cluster.version/cluster.privateRegistry data.

Default version is exposed via settings as well as systemImages per Version map.