### PR TITLE
add project to managerment context as helm controller is using it

### DIFF
--- a/config/context.go
+++ b/config/context.go
@@ -48,10 +48,10 @@ type ManagementContext struct {
 	Schemas           *types.Schemas
 	Scheme            *runtime.Scheme
 	AccessControl     types.AccessControl
-
-	Management managementv3.Interface
-	RBAC       rbacv1.Interface
-	Core       corev1.Interface
+	Project           projectv3.Interface
+	Management        managementv3.Interface
+	RBAC              rbacv1.Interface
+	Core              corev1.Interface
 }
 
 func (c *ManagementContext) controllers() []controller.Starter {
@@ -59,6 +59,7 @@ func (c *ManagementContext) controllers() []controller.Starter {
 		c.Management,
 		c.RBAC,
 		c.Core,
+		c.Project,
 	}
 }
 
@@ -150,6 +151,10 @@ func NewManagementContext(config rest.Config) (*ManagementContext, error) {
 	}
 
 	context.Core, err = corev1.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	context.Project, err = projectv3.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
rancher/rancher is using project in the management context. The commit https://github.com/rancher/rancher/commit/4ba174e01c84bfa8b78e68a4ea5c9e48dc2931f9 made the change for types/config/context.go in the vendor. The same change should be made to types, otherwise using trash will break rancher/rancher.