### PR TITLE
do not use pointer in the mapper

### DIFF
--- a/apis/management.cattle.io/v3/alerting_types.go
+++ b/apis/management.cattle.io/v3/alerting_types.go
@@ -69,19 +69,19 @@ type TargetNode struct {
 	NodeName     string            `json:"nodeName,omitempty" norman:"type=reference[node]"`
 	Selector     map[string]string `json:"selector,omitempty"`
 	Condition    string            `json:"condition,omitempty" norman:"required,options=notready|mem|cpu,default=notready"`
-	MemThreshold int               `json:"memThreshold,omitempty" norman:"min=1,max=100"`
-	CPUThreshold int               `json:"cpuThreshold,omitempty" norman:"min=1"`
+	MemThreshold int               `json:"memThreshold,omitempty" norman:"min=1,max=100,default=70"`
+	CPUThreshold int               `json:"cpuThreshold,omitempty" norman:"min=1,default=70"`
 }
 
 type TargetPod struct {
 	PodName                string `json:"podName,omitempty" norman:"required,type=reference[/v3/projects/schemas/pod]"`
 	Condition              string `json:"condition,omitempty" norman:"required,options=notrunning|notscheduled|restarts,default=notrunning"`
-	RestartTimes           int    `json:"restartTimes,omitempty" norman:"min=1"`
-	RestartIntervalSeconds int    `json:"restartIntervalSeconds,omitempty"  norman:"min=1"`
+	RestartTimes           int    `json:"restartTimes,omitempty" norman:"min=1,default=3"`
+	RestartIntervalSeconds int    `json:"restartIntervalSeconds,omitempty"  norman:"min=1,default=300"`
 }
 
 type TargetEvent struct {
-	Type         string `json:"type,omitempty" norman:"required,options=Normal|Warning,default=warning"`
+	Type         string `json:"type,omitempty" norman:"required,options=Normal|Warning,default=Warning"`
 	ResourceKind string `json:"resourceKind,omitempty" norman:"required,options=Pod|Node|Deployment|Statefulset|Daemonset"`
 }
 
@@ -89,7 +89,7 @@ type TargetWorkload struct {
 	WorkloadID          string            `json:"workloadId,omitempty"`
 	Type                string            `json:"type,omitempty" norman:"required,options=deployment|statefulset|daemonset,default=deployment"`
 	Selector            map[string]string `json:"selector,omitempty"`
-	AvailablePercentage int               `json:"availablePercentage,omitempty" norman:"required,min=1,max=100"`
+	AvailablePercentage int               `json:"availablePercentage,omitempty" norman:"required,min=1,max=100,default=70"`
 }
 
 type TargetSystemService struct {
@@ -97,7 +97,7 @@ type TargetSystemService struct {
 }
 
 type AlertStatus struct {
-	State string `json:"state,omitempty" norman:"required,options=active|inactive|alerting|muted,default=active"`
+	AlertState string `json:"alertState,omitempty" norman:"options=active|inactive|alerting|muted,default=active"`
 }
 
 type Notifier struct {

--- a/apis/management.cattle.io/v3/schema/schema.go
+++ b/apis/management.cattle.io/v3/schema/schema.go
@@ -321,12 +321,12 @@ func globalTypes(schema *types.Schemas) *types.Schemas {
 
 func alertTypes(schema *types.Schemas) *types.Schemas {
 	return schema.
-		AddMapperForType(&Version, &v3.Notifier{},
+		AddMapperForType(&Version, v3.Notifier{},
 			m.DisplayName{}).
-		AddMapperForType(&Version, &v3.ClusterAlert{},
+		AddMapperForType(&Version, v3.ClusterAlert{},
 			&m.Embed{Field: "status"},
 			m.DisplayName{}).
-		AddMapperForType(&Version, &v3.ProjectAlert{},
+		AddMapperForType(&Version, v3.ProjectAlert{},
 			&m.Embed{Field: "status"},
 			m.DisplayName{}).
 		MustImport(&Version, v3.Notification{}).

--- a/client/management/v3/zz_generated_alert_status.go
+++ b/client/management/v3/zz_generated_alert_status.go
@@ -1,10 +1,10 @@
 package client
 
 const (
-	AlertStatusType       = "alertStatus"
-	AlertStatusFieldState = "state"
+	AlertStatusType            = "alertStatus"
+	AlertStatusFieldAlertState = "alertState"
 )
 
 type AlertStatus struct {
-	State string `json:"state,omitempty"`
+	AlertState string `json:"alertState,omitempty"`
 }

--- a/client/management/v3/zz_generated_cluster_alert.go
+++ b/client/management/v3/zz_generated_cluster_alert.go
@@ -6,12 +6,12 @@ import (
 
 const (
 	ClusterAlertType                       = "clusterAlert"
+	ClusterAlertFieldAlertState            = "alertState"
 	ClusterAlertFieldAnnotations           = "annotations"
 	ClusterAlertFieldClusterId             = "clusterId"
 	ClusterAlertFieldCreated               = "created"
 	ClusterAlertFieldCreatorID             = "creatorId"
 	ClusterAlertFieldDescription           = "description"
-	ClusterAlertFieldDisplayName           = "displayName"
 	ClusterAlertFieldInitialWaitSeconds    = "initialWaitSeconds"
 	ClusterAlertFieldLabels                = "labels"
 	ClusterAlertFieldName                  = "name"
@@ -22,7 +22,6 @@ const (
 	ClusterAlertFieldRepeatIntervalSeconds = "repeatIntervalSeconds"
 	ClusterAlertFieldSeverity              = "severity"
 	ClusterAlertFieldState                 = "state"
-	ClusterAlertFieldStatus                = "status"
 	ClusterAlertFieldTargetEvent           = "targetEvent"
 	ClusterAlertFieldTargetNode            = "targetNode"
 	ClusterAlertFieldTargetSystemService   = "targetSystemService"
@@ -33,12 +32,12 @@ const (
 
 type ClusterAlert struct {
 	types.Resource
+	AlertState            string               `json:"alertState,omitempty"`
 	Annotations           map[string]string    `json:"annotations,omitempty"`
 	ClusterId             string               `json:"clusterId,omitempty"`
 	Created               string               `json:"created,omitempty"`
 	CreatorID             string               `json:"creatorId,omitempty"`
 	Description           string               `json:"description,omitempty"`
-	DisplayName           string               `json:"displayName,omitempty"`
 	InitialWaitSeconds    *int64               `json:"initialWaitSeconds,omitempty"`
 	Labels                map[string]string    `json:"labels,omitempty"`
 	Name                  string               `json:"name,omitempty"`
@@ -49,7 +48,6 @@ type ClusterAlert struct {
 	RepeatIntervalSeconds *int64               `json:"repeatIntervalSeconds,omitempty"`
 	Severity              string               `json:"severity,omitempty"`
 	State                 string               `json:"state,omitempty"`
-	Status                *AlertStatus         `json:"status,omitempty"`
 	TargetEvent           *TargetEvent         `json:"targetEvent,omitempty"`
 	TargetNode            *TargetNode          `json:"targetNode,omitempty"`
 	TargetSystemService   *TargetSystemService `json:"targetSystemService,omitempty"`

--- a/client/management/v3/zz_generated_notifier.go
+++ b/client/management/v3/zz_generated_notifier.go
@@ -11,7 +11,6 @@ const (
 	NotifierFieldCreated              = "created"
 	NotifierFieldCreatorID            = "creatorId"
 	NotifierFieldDescription          = "description"
-	NotifierFieldDisplayName          = "displayName"
 	NotifierFieldLabels               = "labels"
 	NotifierFieldName                 = "name"
 	NotifierFieldNamespaceId          = "namespaceId"
@@ -35,7 +34,6 @@ type Notifier struct {
 	Created              string            `json:"created,omitempty"`
 	CreatorID            string            `json:"creatorId,omitempty"`
 	Description          string            `json:"description,omitempty"`
-	DisplayName          string            `json:"displayName,omitempty"`
 	Labels               map[string]string `json:"labels,omitempty"`
 	Name                 string            `json:"name,omitempty"`
 	NamespaceId          string            `json:"namespaceId,omitempty"`

--- a/client/management/v3/zz_generated_project_alert.go
+++ b/client/management/v3/zz_generated_project_alert.go
@@ -6,11 +6,11 @@ import (
 
 const (
 	ProjectAlertType                       = "projectAlert"
+	ProjectAlertFieldAlertState            = "alertState"
 	ProjectAlertFieldAnnotations           = "annotations"
 	ProjectAlertFieldCreated               = "created"
 	ProjectAlertFieldCreatorID             = "creatorId"
 	ProjectAlertFieldDescription           = "description"
-	ProjectAlertFieldDisplayName           = "displayName"
 	ProjectAlertFieldInitialWaitSeconds    = "initialWaitSeconds"
 	ProjectAlertFieldLabels                = "labels"
 	ProjectAlertFieldName                  = "name"
@@ -22,7 +22,6 @@ const (
 	ProjectAlertFieldRepeatIntervalSeconds = "repeatIntervalSeconds"
 	ProjectAlertFieldSeverity              = "severity"
 	ProjectAlertFieldState                 = "state"
-	ProjectAlertFieldStatus                = "status"
 	ProjectAlertFieldTargetPod             = "targetPod"
 	ProjectAlertFieldTargetWorkload        = "targetWorkload"
 	ProjectAlertFieldTransitioning         = "transitioning"
@@ -32,11 +31,11 @@ const (
 
 type ProjectAlert struct {
 	types.Resource
+	AlertState            string            `json:"alertState,omitempty"`
 	Annotations           map[string]string `json:"annotations,omitempty"`
 	Created               string            `json:"created,omitempty"`
 	CreatorID             string            `json:"creatorId,omitempty"`
 	Description           string            `json:"description,omitempty"`
-	DisplayName           string            `json:"displayName,omitempty"`
 	InitialWaitSeconds    *int64            `json:"initialWaitSeconds,omitempty"`
 	Labels                map[string]string `json:"labels,omitempty"`
 	Name                  string            `json:"name,omitempty"`
@@ -48,7 +47,6 @@ type ProjectAlert struct {
 	RepeatIntervalSeconds *int64            `json:"repeatIntervalSeconds,omitempty"`
 	Severity              string            `json:"severity,omitempty"`
 	State                 string            `json:"state,omitempty"`
-	Status                *AlertStatus      `json:"status,omitempty"`
 	TargetPod             *TargetPod        `json:"targetPod,omitempty"`
 	TargetWorkload        *TargetWorkload   `json:"targetWorkload,omitempty"`
 	Transitioning         string            `json:"transitioning,omitempty"`


### PR DESCRIPTION
This PR change field name from State to AlertState. It will break rancher if rancher is using it. I have another PR for rancher https://github.com/rancher/rancher/pull/11453, which should be merged immediately after this PR is merged.