### PR TITLE
do not use pointer in mapper for pipeline types

### DIFF
--- a/apis/management.cattle.io/v3/pipeline_types.go
+++ b/apis/management.cattle.io/v3/pipeline_types.go
@@ -78,7 +78,7 @@ type GithubClusterConfig struct {
 }
 
 type PipelineStatus struct {
-	State           string `json:"state,omitempty" norman:"required,options=active|inactive,default=active"`
+	PipelineState   string `json:"pipelineState,omitempty" norman:"required,options=active|inactive,default=active"`
 	NextRun         int    `json:"nextRun" yaml:"nextRun,omitempty" norman:"default=1,min=1"`
 	LastExecutionID string `json:"lastExecutionId,omitempty" yaml:"lastExecutionId,omitempty"`
 	LastRunState    string `json:"lastRunState,omitempty" yaml:"lastRunState,omitempty"`
@@ -144,11 +144,11 @@ type PipelineExecutionSpec struct {
 }
 
 type PipelineExecutionStatus struct {
-	Commit  string        `json:"commit,omitempty"`
-	State   string        `json:"state,omitempty"`
-	Started string        `json:"started,omitempty"`
-	Ended   string        `json:"ended,omitempty"`
-	Stages  []StageStatus `json:"stages,omitempty"`
+	Commit         string        `json:"commit,omitempty"`
+	ExecutionState string        `json:"executionState,omitempty"`
+	Started        string        `json:"started,omitempty"`
+	Ended          string        `json:"ended,omitempty"`
+	Stages         []StageStatus `json:"stages,omitempty"`
 }
 
 type StageStatus struct {

--- a/apis/management.cattle.io/v3/schema/schema.go
+++ b/apis/management.cattle.io/v3/schema/schema.go
@@ -365,18 +365,15 @@ func alertTypes(schema *types.Schemas) *types.Schemas {
 
 func pipelineTypes(schema *types.Schemas) *types.Schemas {
 	return schema.
-		AddMapperForType(&Version, &v3.ClusterPipeline{},
-			m.DisplayName{}).
-		AddMapperForType(&Version, &v3.Pipeline{},
+		AddMapperForType(&Version, v3.ClusterPipeline{}).
+		AddMapperForType(&Version, v3.Pipeline{},
 			&m.Embed{Field: "status"},
 			m.DisplayName{}).
-		AddMapperForType(&Version, &v3.PipelineExecution{},
-			&m.Embed{Field: "status"},
-			m.DisplayName{}).
-		AddMapperForType(&Version, &v3.SourceCodeCredential{},
-			m.DisplayName{}).
-		AddMapperForType(&Version, &v3.SourceCodeRepository{}, m.DisplayName{}).
-		AddMapperForType(&Version, &v3.PipelineExecutionLog{}).
+		AddMapperForType(&Version, v3.PipelineExecution{},
+			&m.Embed{Field: "status"}).
+		AddMapperForType(&Version, v3.SourceCodeCredential{}).
+		AddMapperForType(&Version, v3.SourceCodeRepository{}).
+		AddMapperForType(&Version, v3.PipelineExecutionLog{}).
 		MustImport(&Version, v3.AuthAppInput{}).
 		MustImport(&Version, v3.AuthUserInput{}).
 		MustImportAndCustomize(&Version, v3.SourceCodeCredential{}, func(schema *types.Schema) {

--- a/client/management/v3/zz_generated_pipeline.go
+++ b/client/management/v3/zz_generated_pipeline.go
@@ -9,22 +9,28 @@ const (
 	PipelineFieldAnnotations           = "annotations"
 	PipelineFieldCreated               = "created"
 	PipelineFieldCreatorID             = "creatorId"
-	PipelineFieldDisplayName           = "displayName"
 	PipelineFieldLabels                = "labels"
+	PipelineFieldLastExecutionID       = "lastExecutionId"
+	PipelineFieldLastRunState          = "lastRunState"
+	PipelineFieldLastStarted           = "lastStarted"
 	PipelineFieldName                  = "name"
 	PipelineFieldNamespaceId           = "namespaceId"
+	PipelineFieldNextRun               = "nextRun"
+	PipelineFieldNextStart             = "nextStart"
 	PipelineFieldOwnerReferences       = "ownerReferences"
+	PipelineFieldPipelineState         = "pipelineState"
 	PipelineFieldProjectId             = "projectId"
 	PipelineFieldRemoved               = "removed"
 	PipelineFieldStages                = "stages"
 	PipelineFieldState                 = "state"
-	PipelineFieldStatus                = "status"
+	PipelineFieldToken                 = "token"
 	PipelineFieldTransitioning         = "transitioning"
 	PipelineFieldTransitioningMessage  = "transitioningMessage"
 	PipelineFieldTriggerCronExpression = "triggerCronExpression"
 	PipelineFieldTriggerCronTimezone   = "triggerCronTimezone"
 	PipelineFieldTriggerWebhook        = "triggerWebhook"
 	PipelineFieldUuid                  = "uuid"
+	PipelineFieldWebHookID             = "webhookId"
 )
 
 type Pipeline struct {
@@ -32,22 +38,28 @@ type Pipeline struct {
 	Annotations           map[string]string `json:"annotations,omitempty"`
 	Created               string            `json:"created,omitempty"`
 	CreatorID             string            `json:"creatorId,omitempty"`
-	DisplayName           string            `json:"displayName,omitempty"`
 	Labels                map[string]string `json:"labels,omitempty"`
+	LastExecutionID       string            `json:"lastExecutionId,omitempty"`
+	LastRunState          string            `json:"lastRunState,omitempty"`
+	LastStarted           string            `json:"lastStarted,omitempty"`
 	Name                  string            `json:"name,omitempty"`
 	NamespaceId           string            `json:"namespaceId,omitempty"`
+	NextRun               *int64            `json:"nextRun,omitempty"`
+	NextStart             string            `json:"nextStart,omitempty"`
 	OwnerReferences       []OwnerReference  `json:"ownerReferences,omitempty"`
+	PipelineState         string            `json:"pipelineState,omitempty"`
 	ProjectId             string            `json:"projectId,omitempty"`
 	Removed               string            `json:"removed,omitempty"`
 	Stages                []Stage           `json:"stages,omitempty"`
 	State                 string            `json:"state,omitempty"`
-	Status                *PipelineStatus   `json:"status,omitempty"`
+	Token                 string            `json:"token,omitempty"`
 	Transitioning         string            `json:"transitioning,omitempty"`
 	TransitioningMessage  string            `json:"transitioningMessage,omitempty"`
 	TriggerCronExpression string            `json:"triggerCronExpression,omitempty"`
 	TriggerCronTimezone   string            `json:"triggerCronTimezone,omitempty"`
 	TriggerWebhook        bool              `json:"triggerWebhook,omitempty"`
 	Uuid                  string            `json:"uuid,omitempty"`
+	WebHookID             string            `json:"webhookId,omitempty"`
 }
 type PipelineCollection struct {
 	types.Collection

--- a/client/management/v3/zz_generated_pipeline_execution.go
+++ b/client/management/v3/zz_generated_pipeline_execution.go
@@ -7,8 +7,11 @@ import (
 const (
 	PipelineExecutionType                      = "pipelineExecution"
 	PipelineExecutionFieldAnnotations          = "annotations"
+	PipelineExecutionFieldCommit               = "commit"
 	PipelineExecutionFieldCreated              = "created"
 	PipelineExecutionFieldCreatorID            = "creatorId"
+	PipelineExecutionFieldEnded                = "ended"
+	PipelineExecutionFieldExecutionState       = "executionState"
 	PipelineExecutionFieldLabels               = "labels"
 	PipelineExecutionFieldName                 = "name"
 	PipelineExecutionFieldNamespaceId          = "namespaceId"
@@ -18,8 +21,9 @@ const (
 	PipelineExecutionFieldProjectId            = "projectId"
 	PipelineExecutionFieldRemoved              = "removed"
 	PipelineExecutionFieldRun                  = "run"
+	PipelineExecutionFieldStages               = "stages"
+	PipelineExecutionFieldStarted              = "started"
 	PipelineExecutionFieldState                = "state"
-	PipelineExecutionFieldStatus               = "status"
 	PipelineExecutionFieldTransitioning        = "transitioning"
 	PipelineExecutionFieldTransitioningMessage = "transitioningMessage"
 	PipelineExecutionFieldTriggerUserId        = "triggerUserId"
@@ -29,25 +33,29 @@ const (
 
 type PipelineExecution struct {
 	types.Resource
-	Annotations          map[string]string        `json:"annotations,omitempty"`
-	Created              string                   `json:"created,omitempty"`
-	CreatorID            string                   `json:"creatorId,omitempty"`
-	Labels               map[string]string        `json:"labels,omitempty"`
-	Name                 string                   `json:"name,omitempty"`
-	NamespaceId          string                   `json:"namespaceId,omitempty"`
-	OwnerReferences      []OwnerReference         `json:"ownerReferences,omitempty"`
-	Pipeline             *Pipeline                `json:"pipeline,omitempty"`
-	PipelineId           string                   `json:"pipelineId,omitempty"`
-	ProjectId            string                   `json:"projectId,omitempty"`
-	Removed              string                   `json:"removed,omitempty"`
-	Run                  *int64                   `json:"run,omitempty"`
-	State                string                   `json:"state,omitempty"`
-	Status               *PipelineExecutionStatus `json:"status,omitempty"`
-	Transitioning        string                   `json:"transitioning,omitempty"`
-	TransitioningMessage string                   `json:"transitioningMessage,omitempty"`
-	TriggerUserId        string                   `json:"triggerUserId,omitempty"`
-	TriggeredBy          string                   `json:"triggeredBy,omitempty"`
-	Uuid                 string                   `json:"uuid,omitempty"`
+	Annotations          map[string]string `json:"annotations,omitempty"`
+	Commit               string            `json:"commit,omitempty"`
+	Created              string            `json:"created,omitempty"`
+	CreatorID            string            `json:"creatorId,omitempty"`
+	Ended                string            `json:"ended,omitempty"`
+	ExecutionState       string            `json:"executionState,omitempty"`
+	Labels               map[string]string `json:"labels,omitempty"`
+	Name                 string            `json:"name,omitempty"`
+	NamespaceId          string            `json:"namespaceId,omitempty"`
+	OwnerReferences      []OwnerReference  `json:"ownerReferences,omitempty"`
+	Pipeline             *Pipeline         `json:"pipeline,omitempty"`
+	PipelineId           string            `json:"pipelineId,omitempty"`
+	ProjectId            string            `json:"projectId,omitempty"`
+	Removed              string            `json:"removed,omitempty"`
+	Run                  *int64            `json:"run,omitempty"`
+	Stages               []StageStatus     `json:"stages,omitempty"`
+	Started              string            `json:"started,omitempty"`
+	State                string            `json:"state,omitempty"`
+	Transitioning        string            `json:"transitioning,omitempty"`
+	TransitioningMessage string            `json:"transitioningMessage,omitempty"`
+	TriggerUserId        string            `json:"triggerUserId,omitempty"`
+	TriggeredBy          string            `json:"triggeredBy,omitempty"`
+	Uuid                 string            `json:"uuid,omitempty"`
 }
 type PipelineExecutionCollection struct {
 	types.Collection

--- a/client/management/v3/zz_generated_pipeline_execution_status.go
+++ b/client/management/v3/zz_generated_pipeline_execution_status.go
@@ -1,18 +1,18 @@
 package client
 
 const (
-	PipelineExecutionStatusType         = "pipelineExecutionStatus"
-	PipelineExecutionStatusFieldCommit  = "commit"
-	PipelineExecutionStatusFieldEnded   = "ended"
-	PipelineExecutionStatusFieldStages  = "stages"
-	PipelineExecutionStatusFieldStarted = "started"
-	PipelineExecutionStatusFieldState   = "state"
+	PipelineExecutionStatusType                = "pipelineExecutionStatus"
+	PipelineExecutionStatusFieldCommit         = "commit"
+	PipelineExecutionStatusFieldEnded          = "ended"
+	PipelineExecutionStatusFieldExecutionState = "executionState"
+	PipelineExecutionStatusFieldStages         = "stages"
+	PipelineExecutionStatusFieldStarted        = "started"
 )
 
 type PipelineExecutionStatus struct {
-	Commit  string        `json:"commit,omitempty"`
-	Ended   string        `json:"ended,omitempty"`
-	Stages  []StageStatus `json:"stages,omitempty"`
-	Started string        `json:"started,omitempty"`
-	State   string        `json:"state,omitempty"`
+	Commit         string        `json:"commit,omitempty"`
+	Ended          string        `json:"ended,omitempty"`
+	ExecutionState string        `json:"executionState,omitempty"`
+	Stages         []StageStatus `json:"stages,omitempty"`
+	Started        string        `json:"started,omitempty"`
 }

--- a/client/management/v3/zz_generated_pipeline_status.go
+++ b/client/management/v3/zz_generated_pipeline_status.go
@@ -7,7 +7,7 @@ const (
 	PipelineStatusFieldLastStarted     = "lastStarted"
 	PipelineStatusFieldNextRun         = "nextRun"
 	PipelineStatusFieldNextStart       = "nextStart"
-	PipelineStatusFieldState           = "state"
+	PipelineStatusFieldPipelineState   = "pipelineState"
 	PipelineStatusFieldToken           = "token"
 	PipelineStatusFieldWebHookID       = "webhookId"
 )
@@ -18,7 +18,7 @@ type PipelineStatus struct {
 	LastStarted     string `json:"lastStarted,omitempty"`
 	NextRun         *int64 `json:"nextRun,omitempty"`
 	NextStart       string `json:"nextStart,omitempty"`
-	State           string `json:"state,omitempty"`
+	PipelineState   string `json:"pipelineState,omitempty"`
 	Token           string `json:"token,omitempty"`
 	WebHookID       string `json:"webhookId,omitempty"`
 }


### PR DESCRIPTION
In the meantime, removed unused mappers and rename `state` fields to avoid conflicts.