### PR TITLE
Rename TargetEvent Type in api side

### DIFF
--- a/apis/management.cattle.io/v3/alerting_types.go
+++ b/apis/management.cattle.io/v3/alerting_types.go
@@ -81,13 +81,12 @@ type TargetPod struct {
 }
 
 type TargetEvent struct {
-	Type         string `json:"type,omitempty" norman:"required,options=Normal|Warning,default=Warning"`
+	EventType    string `json:"eventType,omitempty" norman:"required,options=Normal|Warning,default=Warning"`
 	ResourceKind string `json:"resourceKind,omitempty" norman:"required,options=Pod|Node|Deployment|Statefulset|Daemonset"`
 }
 
 type TargetWorkload struct {
 	WorkloadID          string            `json:"workloadId,omitempty"`
-	Type                string            `json:"type,omitempty" norman:"required,options=deployment|statefulset|daemonset,default=deployment"`
 	Selector            map[string]string `json:"selector,omitempty"`
 	AvailablePercentage int               `json:"availablePercentage,omitempty" norman:"required,min=1,max=100,default=70"`
 }

--- a/client/management/v3/zz_generated_target_event.go
+++ b/client/management/v3/zz_generated_target_event.go
@@ -2,11 +2,11 @@ package client
 
 const (
 	TargetEventType              = "targetEvent"
+	TargetEventFieldEventType    = "eventType"
 	TargetEventFieldResourceKind = "resourceKind"
-	TargetEventFieldType         = "type"
 )
 
 type TargetEvent struct {
+	EventType    string `json:"eventType,omitempty" yaml:"eventType,omitempty"`
 	ResourceKind string `json:"resourceKind,omitempty" yaml:"resourceKind,omitempty"`
-	Type         string `json:"type,omitempty" yaml:"type,omitempty"`
 }

--- a/client/management/v3/zz_generated_target_workload.go
+++ b/client/management/v3/zz_generated_target_workload.go
@@ -4,13 +4,11 @@ const (
 	TargetWorkloadType                     = "targetWorkload"
 	TargetWorkloadFieldAvailablePercentage = "availablePercentage"
 	TargetWorkloadFieldSelector            = "selector"
-	TargetWorkloadFieldType                = "type"
 	TargetWorkloadFieldWorkloadID          = "workloadId"
 )
 
 type TargetWorkload struct {
 	AvailablePercentage *int64            `json:"availablePercentage,omitempty" yaml:"availablePercentage,omitempty"`
 	Selector            map[string]string `json:"selector,omitempty" yaml:"selector,omitempty"`
-	Type                string            `json:"type,omitempty" yaml:"type,omitempty"`
 	WorkloadID          string            `json:"workloadId,omitempty" yaml:"workloadId,omitempty"`
 }


### PR DESCRIPTION
related issue https://github.com/rancher/rancher/issues/11778

1. rename type to eventType for TargetEvent.Type in API side.
2. remove the useless Type field from TargetWorkload