### PR TITLE
Add alt names

### DIFF
--- a/apis/management.cattle.io/v3/rke_types.go
+++ b/apis/management.cattle.io/v3/rke_types.go
@@ -237,6 +237,8 @@ type AuthnConfig struct {
 	Strategy string `yaml:"strategy" json:"strategy,omitempty"`
 	// Authentication options
 	Options map[string]string `yaml:"options" json:"options,omitempty"`
+	// List of additional hostnames and IPs to include in the api server PKI cert
+	SANs []string `yaml:"sans" json:"sans,omitempty"`
 }
 
 type AuthzConfig struct {

--- a/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -1089,6 +1089,11 @@ func (in *AuthnConfig) DeepCopyInto(out *AuthnConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.SANs != nil {
+		in, out := &in.SANs, &out.SANs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/client/management/v3/zz_generated_authn_config.go
+++ b/client/management/v3/zz_generated_authn_config.go
@@ -3,10 +3,12 @@ package client
 const (
 	AuthnConfigType          = "authnConfig"
 	AuthnConfigFieldOptions  = "options"
+	AuthnConfigFieldSANs     = "sans"
 	AuthnConfigFieldStrategy = "strategy"
 )
 
 type AuthnConfig struct {
 	Options  map[string]string `json:"options,omitempty" yaml:"options,omitempty"`
+	SANs     []string          `json:"sans,omitempty" yaml:"sans,omitempty"`
 	Strategy string            `json:"strategy,omitempty" yaml:"strategy,omitempty"`
 }


### PR DESCRIPTION
Adding support for additional DNS names and IPs (Alt names) used for PKI (certificates) in rke.