### PR TITLE
Set correct etcd version for 1.9

### DIFF
--- a/apis/management.cattle.io/v3/k8s_defaults.go
+++ b/apis/management.cattle.io/v3/k8s_defaults.go
@@ -75,7 +75,7 @@ var (
 
 	// v19 system images defaults
 	v19SystemImages = RKESystemImages{
-		Etcd:                      "rancher/coreos-etcd:v3.0.17",
+		Etcd:                      "rancher/coreos-etcd:v3.1.12",
 		Kubernetes:                "rancher/k8s:" + K8sV19,
 		Alpine:                    "alpine:latest",
 		NginxProxy:                "rancher/rke-nginx-proxy:v0.1.1",


### PR DESCRIPTION
Originally, supported etcd for 1.9 was `3.1.10` but according to this PR (https://github.com/kubernetes/kubernetes/pull/60998), `3.1.12` was included for 1.10 and will be backported to 1.9.