### PR TITLE
Change ExtraArgs type to map[string]string at IngressConfig rke types

### DIFF
--- a/apis/management.cattle.io/v3/rke_types.go
+++ b/apis/management.cattle.io/v3/rke_types.go
@@ -251,7 +251,7 @@ type IngressConfig struct {
 	// NodeSelector key pair
 	NodeSelector map[string]string `yaml:"node_selector" json:"nodeSelector,omitempty"`
 	// Ingress controller extra arguments
-	ExtraArgs []string `yaml:"extra_args" json:"extraArgs,omitempty"`
+	ExtraArgs map[string]string `yaml:"extra_args" json:"extraArgs,omitempty"`
 }
 
 type RKEPlan struct {

--- a/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -3218,8 +3218,10 @@ func (in *IngressConfig) DeepCopyInto(out *IngressConfig) {
 	}
 	if in.ExtraArgs != nil {
 		in, out := &in.ExtraArgs, &out.ExtraArgs
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	return
 }

--- a/client/management/v3/zz_generated_ingress_config.go
+++ b/client/management/v3/zz_generated_ingress_config.go
@@ -9,7 +9,7 @@ const (
 )
 
 type IngressConfig struct {
-	ExtraArgs    []string          `json:"extraArgs,omitempty" yaml:"extraArgs,omitempty"`
+	ExtraArgs    map[string]string `json:"extraArgs,omitempty" yaml:"extraArgs,omitempty"`
 	NodeSelector map[string]string `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty"`
 	Options      map[string]string `json:"options,omitempty" yaml:"options,omitempty"`
 	Provider     string            `json:"provider,omitempty" yaml:"provider,omitempty"`


### PR DESCRIPTION
Making `extra_args` at ingress-controller consistent in name and type with `extra_args` at base services. 

More info at https://github.com/rancher/rke/pull/501