### PR TITLE
fields for git tag trigger support in pipeline

### DIFF
--- a/apis/management.cattle.io/v3/pipeline_types.go
+++ b/apis/management.cattle.io/v3/pipeline_types.go
@@ -112,6 +112,7 @@ type PipelineSpec struct {
 	DisplayName           string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	TriggerWebhookPush    bool   `json:"triggerWebhookPush,omitempty" yaml:"triggerWebhookPush,omitempty"`
 	TriggerWebhookPr      bool   `json:"triggerWebhookPr,omitempty" yaml:"triggerWebhookPr,omitempty"`
+	TriggerWebhookTag     bool   `json:"triggerWebhookTag,omitempty" yaml:"triggerWebhookTag,omitempty"`
 	TriggerCronTimezone   string `json:"triggerCronTimezone,omitempty" yaml:"triggerCronTimezone,omitempty"`
 	TriggerCronExpression string `json:"triggerCronExpression,omitempty" yaml:"triggerCronExpression,omitempty"`
 
@@ -181,11 +182,12 @@ type PipelineExecutionSpec struct {
 type PipelineExecutionStatus struct {
 	Conditions []PipelineCondition `json:"conditions,omitempty"`
 
-	Commit         string        `json:"commit,omitempty"`
-	ExecutionState string        `json:"executionState,omitempty"`
-	Started        string        `json:"started,omitempty"`
-	Ended          string        `json:"ended,omitempty"`
-	Stages         []StageStatus `json:"stages,omitempty"`
+	Commit         string            `json:"commit,omitempty"`
+	ExecutionState string            `json:"executionState,omitempty"`
+	Started        string            `json:"started,omitempty"`
+	Ended          string            `json:"ended,omitempty"`
+	Stages         []StageStatus     `json:"stages,omitempty"`
+	EnvVars        map[string]string `json:"envVars,omitempty"`
 }
 
 type StageStatus struct {

--- a/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -4699,6 +4699,13 @@ func (in *PipelineExecutionStatus) DeepCopyInto(out *PipelineExecutionStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.EnvVars != nil {
+		in, out := &in.EnvVars, &out.EnvVars
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/client/management/v3/zz_generated_pipeline.go
+++ b/client/management/v3/zz_generated_pipeline.go
@@ -32,6 +32,7 @@ const (
 	PipelineFieldTriggerCronTimezone   = "triggerCronTimezone"
 	PipelineFieldTriggerWebhookPr      = "triggerWebhookPr"
 	PipelineFieldTriggerWebhookPush    = "triggerWebhookPush"
+	PipelineFieldTriggerWebhookTag     = "triggerWebhookTag"
 	PipelineFieldUuid                  = "uuid"
 	PipelineFieldWebHookID             = "webhookId"
 )
@@ -64,6 +65,7 @@ type Pipeline struct {
 	TriggerCronTimezone   string                `json:"triggerCronTimezone,omitempty" yaml:"triggerCronTimezone,omitempty"`
 	TriggerWebhookPr      bool                  `json:"triggerWebhookPr,omitempty" yaml:"triggerWebhookPr,omitempty"`
 	TriggerWebhookPush    bool                  `json:"triggerWebhookPush,omitempty" yaml:"triggerWebhookPush,omitempty"`
+	TriggerWebhookTag     bool                  `json:"triggerWebhookTag,omitempty" yaml:"triggerWebhookTag,omitempty"`
 	Uuid                  string                `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 	WebHookID             string                `json:"webhookId,omitempty" yaml:"webhookId,omitempty"`
 }

--- a/client/management/v3/zz_generated_pipeline_execution.go
+++ b/client/management/v3/zz_generated_pipeline_execution.go
@@ -12,6 +12,7 @@ const (
 	PipelineExecutionFieldCreated              = "created"
 	PipelineExecutionFieldCreatorID            = "creatorId"
 	PipelineExecutionFieldEnded                = "ended"
+	PipelineExecutionFieldEnvVars              = "envVars"
 	PipelineExecutionFieldExecutionState       = "executionState"
 	PipelineExecutionFieldLabels               = "labels"
 	PipelineExecutionFieldName                 = "name"
@@ -40,6 +41,7 @@ type PipelineExecution struct {
 	Created              string              `json:"created,omitempty" yaml:"created,omitempty"`
 	CreatorID            string              `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	Ended                string              `json:"ended,omitempty" yaml:"ended,omitempty"`
+	EnvVars              map[string]string   `json:"envVars,omitempty" yaml:"envVars,omitempty"`
 	ExecutionState       string              `json:"executionState,omitempty" yaml:"executionState,omitempty"`
 	Labels               map[string]string   `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Name                 string              `json:"name,omitempty" yaml:"name,omitempty"`

--- a/client/management/v3/zz_generated_pipeline_execution_status.go
+++ b/client/management/v3/zz_generated_pipeline_execution_status.go
@@ -5,6 +5,7 @@ const (
 	PipelineExecutionStatusFieldCommit         = "commit"
 	PipelineExecutionStatusFieldConditions     = "conditions"
 	PipelineExecutionStatusFieldEnded          = "ended"
+	PipelineExecutionStatusFieldEnvVars        = "envVars"
 	PipelineExecutionStatusFieldExecutionState = "executionState"
 	PipelineExecutionStatusFieldStages         = "stages"
 	PipelineExecutionStatusFieldStarted        = "started"
@@ -14,6 +15,7 @@ type PipelineExecutionStatus struct {
 	Commit         string              `json:"commit,omitempty" yaml:"commit,omitempty"`
 	Conditions     []PipelineCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
 	Ended          string              `json:"ended,omitempty" yaml:"ended,omitempty"`
+	EnvVars        map[string]string   `json:"envVars,omitempty" yaml:"envVars,omitempty"`
 	ExecutionState string              `json:"executionState,omitempty" yaml:"executionState,omitempty"`
 	Stages         []StageStatus       `json:"stages,omitempty" yaml:"stages,omitempty"`
 	Started        string              `json:"started,omitempty" yaml:"started,omitempty"`

--- a/client/management/v3/zz_generated_pipeline_spec.go
+++ b/client/management/v3/zz_generated_pipeline_spec.go
@@ -9,6 +9,7 @@ const (
 	PipelineSpecFieldTriggerCronTimezone   = "triggerCronTimezone"
 	PipelineSpecFieldTriggerWebhookPr      = "triggerWebhookPr"
 	PipelineSpecFieldTriggerWebhookPush    = "triggerWebhookPush"
+	PipelineSpecFieldTriggerWebhookTag     = "triggerWebhookTag"
 )
 
 type PipelineSpec struct {
@@ -19,4 +20,5 @@ type PipelineSpec struct {
 	TriggerCronTimezone   string            `json:"triggerCronTimezone,omitempty" yaml:"triggerCronTimezone,omitempty"`
 	TriggerWebhookPr      bool              `json:"triggerWebhookPr,omitempty" yaml:"triggerWebhookPr,omitempty"`
 	TriggerWebhookPush    bool              `json:"triggerWebhookPush,omitempty" yaml:"triggerWebhookPush,omitempty"`
+	TriggerWebhookTag     bool              `json:"triggerWebhookTag,omitempty" yaml:"triggerWebhookTag,omitempty"`
 }


### PR DESCRIPTION
Add `TriggerWebhookTag` field
Add `OptionalEnvVars ` field to store environment variables which is not in execution fields. It stores `CICD_GIT_TAG` for now and is open for extension.

Related issue: https://github.com/rancher/rancher/issues/12624
