### PR TITLE
use specific pipeline image tags

### DIFF
--- a/apis/management.cattle.io/v3/k8s_defaults.go
+++ b/apis/management.cattle.io/v3/k8s_defaults.go
@@ -187,10 +187,10 @@ var (
 			AlertManagerHelper: m("rancher/alertmanager-helper:v0.0.2"),
 		},
 		PipelineSystemImages: PipelineSystemImages{
-			Jenkins:       m("jenkins/jenkins:lts"),
+			Jenkins:       m("jenkins/jenkins:2.107-slim"),
 			JenkinsJnlp:   m("jenkins/jnlp-slave:3.10-1-alpine"),
-			AlpineGit:     m("alpine/git"),
-			PluginsDocker: m("plugins/docker"),
+			AlpineGit:     m("alpine/git:1.0.4"),
+			PluginsDocker: m("plugins/docker:17.12"),
 		},
 		LoggingSystemImages: LoggingSystemImages{
 			Fluentd:                       m("rancher/fluentd:v0.1.7"),


### PR DESCRIPTION
Related images need to be pushed to rancher registries such as `https://hub.docker.com/r/rancher/jenkins-jenkins`
@deniseschannon 