### PR TITLE
Protected role templates

### DIFF
--- a/apis/management.cattle.io/v3/authz_types.go
+++ b/apis/management.cattle.io/v3/authz_types.go
@@ -73,14 +73,18 @@ type RoleTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	DisplayName       string              `json:"displayName,omitempty" norman:"required"`
-	Description       string              `json:"description"`
-	Rules             []rbacv1.PolicyRule `json:"rules,omitempty"`
-	Builtin           bool                `json:"builtin" norman:"nocreate,noupdate"`
-	External          bool                `json:"external"`
-	Hidden            bool                `json:"hidden"`
-	Context           string              `json:"context" norman:"type=string,options=project|cluster"`
-	RoleTemplateNames []string            `json:"roleTemplateNames,omitempty" norman:"type=array[reference[roleTemplate]]"`
+	DisplayName string              `json:"displayName,omitempty" norman:"required"`
+	Description string              `json:"description"`
+	Rules       []rbacv1.PolicyRule `json:"rules,omitempty"`
+	Builtin     bool                `json:"builtin" norman:"nocreate,noupdate"`
+	External    bool                `json:"external"`
+	Hidden      bool                `json:"hidden"`
+	// Enabled is a bool pointer so that it will be backwards compatible with previous versions of rancher. This field
+	// did not always exist. If it were a normal bool, old resources would default to false. With a pointer we can
+	// interpret the absence (nil) of the field to mean true.
+	Enabled           *bool    `json:"enabled,omitempty" norman:"type=boolean,default=true"`
+	Context           string   `json:"context" norman:"type=string,options=project|cluster"`
+	RoleTemplateNames []string `json:"roleTemplateNames,omitempty" norman:"type=array[reference[roleTemplate]]"`
 }
 
 type PodSecurityPolicyTemplate struct {

--- a/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -5996,6 +5996,15 @@ func (in *RoleTemplate) DeepCopyInto(out *RoleTemplate) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Enabled != nil {
+		in, out := &in.Enabled, &out.Enabled
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	if in.RoleTemplateNames != nil {
 		in, out := &in.RoleTemplateNames, &out.RoleTemplateNames
 		*out = make([]string, len(*in))

--- a/client/management/v3/zz_generated_role_template.go
+++ b/client/management/v3/zz_generated_role_template.go
@@ -12,6 +12,7 @@ const (
 	RoleTemplateFieldCreated         = "created"
 	RoleTemplateFieldCreatorID       = "creatorId"
 	RoleTemplateFieldDescription     = "description"
+	RoleTemplateFieldEnabled         = "enabled"
 	RoleTemplateFieldExternal        = "external"
 	RoleTemplateFieldHidden          = "hidden"
 	RoleTemplateFieldLabels          = "labels"
@@ -31,6 +32,7 @@ type RoleTemplate struct {
 	Created         string            `json:"created,omitempty" yaml:"created,omitempty"`
 	CreatorID       string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	Description     string            `json:"description,omitempty" yaml:"description,omitempty"`
+	Enabled         *bool             `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 	External        bool              `json:"external,omitempty" yaml:"external,omitempty"`
 	Hidden          bool              `json:"hidden,omitempty" yaml:"hidden,omitempty"`
 	Labels          map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`


### PR DESCRIPTION
This change adds a disabled field to role templates so admins can prevent them from being assigned to users.

Issue:
https://github.com/rancher/rancher/issues/13418
