### PR TITLE
DNS label as name type for workload proxy stores

### DIFF
--- a/apis/project.cattle.io/v3/schema/schema.go
+++ b/apis/project.cattle.io/v3/schema/schema.go
@@ -119,7 +119,7 @@ func workloadTypes(schemas *types.Schemas) *types.Schemas {
 				"resume": {},
 			}
 			schema.MustCustomizeField("name", func(field types.Field) types.Field {
-				field.Type = "dnsLabel"
+				field.Type = "dnsLabelRestricted"
 				field.Nullable = false
 				field.Required = true
 				return field
@@ -173,6 +173,12 @@ func statefulSetTypes(schemas *types.Schemas) *types.Schemas {
 		MustImport(&Version, v1beta2.StatefulSetSpec{}, statefulSetConfigOverride{}).
 		MustImportAndCustomize(&Version, v1beta2.StatefulSet{}, func(schema *types.Schema) {
 			schema.BaseType = "workload"
+			schema.MustCustomizeField("name", func(field types.Field) types.Field {
+				field.Type = "dnsLabelRestricted"
+				field.Nullable = false
+				field.Required = true
+				return field
+			})
 		}, projectOverride{}, struct {
 			PublicEndpoints string `json:"publicEndpoints" norman:"type=array[publicEndpoint],nocreate,noupdate"`
 		}{})
@@ -201,6 +207,12 @@ func replicaSetTypes(schemas *types.Schemas) *types.Schemas {
 		MustImport(&Version, v1beta1.ReplicaSetSpec{}, replicaSetConfigOverride{}).
 		MustImportAndCustomize(&Version, v1beta1.ReplicaSet{}, func(schema *types.Schema) {
 			schema.BaseType = "workload"
+			schema.MustCustomizeField("name", func(field types.Field) types.Field {
+				field.Type = "dnsLabelRestricted"
+				field.Nullable = false
+				field.Required = true
+				return field
+			})
 		}, projectOverride{}, struct {
 			PublicEndpoints string `json:"publicEndpoints" norman:"type=array[publicEndpoint],nocreate,noupdate"`
 		}{})
@@ -231,6 +243,12 @@ func replicationControllerTypes(schemas *types.Schemas) *types.Schemas {
 			schema.BaseType = "workload"
 			schema.CollectionMethods = []string{http.MethodGet}
 			schema.ResourceMethods = []string{http.MethodGet}
+			schema.MustCustomizeField("name", func(field types.Field) types.Field {
+				field.Type = "dnsLabelRestricted"
+				field.Nullable = false
+				field.Required = true
+				return field
+			})
 		}, projectOverride{}, struct {
 			PublicEndpoints string `json:"publicEndpoints" norman:"type=array[publicEndpoint],nocreate,noupdate"`
 		}{})
@@ -269,6 +287,12 @@ func daemonSetTypes(schemas *types.Schemas) *types.Schemas {
 		MustImport(&Version, v1beta2.DaemonSetSpec{}, daemonSetOverride{}).
 		MustImportAndCustomize(&Version, v1beta2.DaemonSet{}, func(schema *types.Schema) {
 			schema.BaseType = "workload"
+			schema.MustCustomizeField("name", func(field types.Field) types.Field {
+				field.Type = "dnsLabelRestricted"
+				field.Nullable = false
+				field.Required = true
+				return field
+			})
 		}, projectOverride{}, struct {
 			PublicEndpoints string `json:"publicEndpoints" norman:"type=array[publicEndpoint],nocreate,noupdate"`
 		}{})
@@ -298,6 +322,12 @@ func jobTypes(schemas *types.Schemas) *types.Schemas {
 		MustImport(&Version, batchv1.JobSpec{}, jobOverride{}).
 		MustImportAndCustomize(&Version, batchv1.Job{}, func(schema *types.Schema) {
 			schema.BaseType = "workload"
+			schema.MustCustomizeField("name", func(field types.Field) types.Field {
+				field.Type = "dnsLabelRestricted"
+				field.Nullable = false
+				field.Required = true
+				return field
+			})
 		}, projectOverride{}, struct {
 			PublicEndpoints string `json:"publicEndpoints" norman:"type=array[publicEndpoint],nocreate,noupdate"`
 		}{})
@@ -359,6 +389,12 @@ func cronJobTypes(schemas *types.Schemas) *types.Schemas {
 		MustImport(&Version, batchv1beta1.JobTemplateSpec{}).
 		MustImportAndCustomize(&Version, batchv1beta1.CronJob{}, func(schema *types.Schema) {
 			schema.BaseType = "workload"
+			schema.MustCustomizeField("name", func(field types.Field) types.Field {
+				field.Type = "dnsLabelRestricted"
+				field.Nullable = false
+				field.Required = true
+				return field
+			})
 		}, projectOverride{}, struct {
 			PublicEndpoints string `json:"publicEndpoints" norman:"type=array[publicEndpoint],nocreate,noupdate"`
 		}{})
@@ -415,6 +451,12 @@ func deploymentTypes(schemas *types.Schemas) *types.Schemas {
 				"pause":  {},
 				"resume": {},
 			}
+			schema.MustCustomizeField("name", func(field types.Field) types.Field {
+				field.Type = "dnsLabelRestricted"
+				field.Nullable = false
+				field.Required = true
+				return field
+			})
 		}, projectOverride{}, struct {
 			PublicEndpoints string `json:"publicEndpoints" norman:"type=array[publicEndpoint],nocreate,noupdate"`
 		}{})
@@ -590,7 +632,7 @@ func addServiceOrDNSRecord(dns bool) types.SchemasInitFunc {
 					return f
 				})
 				schema.MustCustomizeField("name", func(field types.Field) types.Field {
-					field.Type = "dnsLabel"
+					field.Type = "dnsLabelRestricted"
 					field.Nullable = false
 					field.Required = true
 					return field

--- a/vendor.conf
+++ b/vendor.conf
@@ -7,4 +7,4 @@ golang.org/x/sync                             fd80eb99c8f653c847d294a001bdf2a3a6
 
 
 
-github.com/rancher/norman                     df1aea6651585bc249927e5c42a9bad3082f9be5
+github.com/rancher/norman                     e03c72e8551d1c8f51270da0faa40b1235d03e1c

--- a/vendor/github.com/rancher/norman/generator/generator.go
+++ b/vendor/github.com/rancher/norman/generator/generator.go
@@ -78,6 +78,8 @@ func getTypeString(nullable bool, typeName string, schema *types.Schema, schemas
 		return "intstr.IntOrString"
 	case "dnsLabel":
 		return "string"
+	case "dnsLabelRestricted":
+		return "string"
 	case "hostname":
 		return "string"
 	default:


### PR DESCRIPTION
Instead of putting it on the workload store itself. 
Plus made DNS label more restrictive for services/workloads


Norman PR has to be merged first https://github.com/rancher/norman/pull/168