### PR TITLE
Allow nil value for rollingUpdate field in a deployment

### DIFF
--- a/apis/project.cattle.io/v3/schema/schema.go
+++ b/apis/project.cattle.io/v3/schema/schema.go
@@ -367,7 +367,7 @@ func cronJobTypes(schemas *types.Schemas) *types.Schemas {
 func deploymentTypes(schemas *types.Schemas) *types.Schemas {
 	return schemas.
 		AddMapperForType(&Version, v1beta2.DeploymentStrategy{},
-			&m.Embed{Field: "rollingUpdate"},
+			&m.Embed{Field: "rollingUpdate", EmptyValueOk: true},
 			m.Enum{Field: "type", Options: []string{
 				"Recreate",
 				"RollingUpdate",

--- a/vendor.conf
+++ b/vendor.conf
@@ -5,4 +5,6 @@ k8s.io/kubernetes                             v1.8.3                            
 bitbucket.org/ww/goautoneg                    a547fc61f48d567d5b4ec6f8aee5573d8efce11d https://github.com/rancher/goautoneg.git
 golang.org/x/sync                             fd80eb99c8f653c847d294a001bdf2a3a6f768f5
 
-github.com/rancher/norman                     79b91ea33c9ce18094018b26e86fa2577cac2bdd 
+
+
+github.com/rancher/norman                     d70f95a3d6fc13a9f4554e74b838771ea7c928b2 

--- a/vendor/github.com/rancher/norman/types/encoder.go
+++ b/vendor/github.com/rancher/norman/types/encoder.go
@@ -1,0 +1,25 @@
+package types
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/ghodss/yaml"
+)
+
+func JSONEncoder(writer io.Writer, v interface{}) error {
+	return json.NewEncoder(writer).Encode(v)
+}
+
+func YAMLEncoder(writer io.Writer, v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	buf, err := yaml.JSONToYAML(data)
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(buf)
+	return err
+}

--- a/vendor/github.com/rancher/norman/types/mapper/embed.go
+++ b/vendor/github.com/rancher/norman/types/mapper/embed.go
@@ -13,6 +13,7 @@ type Embed struct {
 	Ignore         []string
 	ignoreOverride bool
 	embeddedFields []string
+	EmptyValueOk   bool
 }
 
 func (e *Embed) FromInternal(data map[string]interface{}) {
@@ -39,6 +40,9 @@ func (e *Embed) ToInternal(data map[string]interface{}) {
 		delete(data, fieldName)
 	}
 	if len(sub) == 0 {
+		if e.EmptyValueOk {
+			data[e.Field] = nil
+		}
 		return
 	}
 	data[e.Field] = sub


### PR DESCRIPTION
Usecase for this: In cases where an Update on the resource will be removing some field, we need to update the existing k8s resource's field by setting its value to explicit nil.

https://github.com/rancher/rancher/issues/13584

@alena1108 review needed.