### PR TITLE
Adding virtual network and subnet options to aks cluster config

### DIFF
--- a/apis/management.cattle.io/v3/cluster_types.go
+++ b/apis/management.cattle.io/v3/cluster_types.go
@@ -196,6 +196,10 @@ type AzureKubernetesServiceConfig struct {
 	TenantID string `json:"tenantId,omitempty" norman:"required"`
 	// Secret associated with the Client ID
 	ClientSecret string `json:"clientSecret,omitempty" norman:"required,type=password"`
+	// Virtual network to use for the AKS cluster
+	VirtualNetwork string `json:"virtualNetwork,omitempty"`
+	// Subnet to use for the AKS Cluster (must be within the virtual network)
+	Subnet string `json:"subnet,omitempty"`
 }
 
 type AmazonElasticContainerServiceConfig struct {

--- a/client/management/v3/zz_generated_azure_kubernetes_service_config.go
+++ b/client/management/v3/zz_generated_azure_kubernetes_service_config.go
@@ -16,9 +16,11 @@ const (
 	AzureKubernetesServiceConfigFieldOsDiskSizeGB         = "osDiskSizeGb"
 	AzureKubernetesServiceConfigFieldResourceGroup        = "resourceGroup"
 	AzureKubernetesServiceConfigFieldSSHPublicKeyContents = "sshPublicKeyContents"
+	AzureKubernetesServiceConfigFieldSubnet               = "subnet"
 	AzureKubernetesServiceConfigFieldSubscriptionID       = "subscriptionId"
 	AzureKubernetesServiceConfigFieldTag                  = "tags"
 	AzureKubernetesServiceConfigFieldTenantID             = "tenantId"
+	AzureKubernetesServiceConfigFieldVirtualNetwork       = "virtualNetwork"
 )
 
 type AzureKubernetesServiceConfig struct {
@@ -36,7 +38,9 @@ type AzureKubernetesServiceConfig struct {
 	OsDiskSizeGB         int64             `json:"osDiskSizeGb,omitempty" yaml:"osDiskSizeGb,omitempty"`
 	ResourceGroup        string            `json:"resourceGroup,omitempty" yaml:"resourceGroup,omitempty"`
 	SSHPublicKeyContents string            `json:"sshPublicKeyContents,omitempty" yaml:"sshPublicKeyContents,omitempty"`
+	Subnet               string            `json:"subnet,omitempty" yaml:"subnet,omitempty"`
 	SubscriptionID       string            `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty"`
 	Tag                  map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
 	TenantID             string            `json:"tenantId,omitempty" yaml:"tenantId,omitempty"`
+	VirtualNetwork       string            `json:"virtualNetwork,omitempty" yaml:"virtualNetwork,omitempty"`
 }


### PR DESCRIPTION
This change adds support for specifying a virtual network and subnet to
an AKS cluster. Both a virtual network and a subnet must be specified
together or the option will be ignored.

Issue:
https://github.com/rancher/rancher/issues/13395