### PR TITLE
Respect the case when pass clusterIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.idea
 /trash.lock
 /types
+*trash.lock

--- a/apis/project.cattle.io/v3/schema/service_spec_mapper.go
+++ b/apis/project.cattle.io/v3/schema/service_spec_mapper.go
@@ -18,10 +18,10 @@ func (e ServiceSpecMapper) ToInternal(data map[string]interface{}) {
 
 	if convert.IsEmpty(data["hostname"]) {
 		data["type"] = "ClusterIP"
-		data["clusterIp"] = "None"
+		data["clusterIP"] = "None"
 	} else {
 		data["type"] = "ExternalName"
-		data["clusterIp"] = ""
+		data["clusterIP"] = ""
 	}
 }
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/14414

k8s 1.8 is more forgiving about the case, therefore clusterIp was translated correctly to clusterIP. Not the case in 1.10 clusters where the exact match is expected