### PR TITLE
Enable mount propagation to kubelet and kubeapi

### DIFF
--- a/apis/management.cattle.io/v3/k8s_defaults.go
+++ b/apis/management.cattle.io/v3/k8s_defaults.go
@@ -293,12 +293,10 @@ var (
 		"v1.10": {
 			KubeAPI: map[string]string{
 				"tls-cipher-suites":        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-				"feature-gates":            "MountPropagation=false",
 				"endpoint-reconciler-type": "lease",
 			},
 			Kubelet: map[string]string{
 				"tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-				"feature-gates":     "MountPropagation=false",
 			},
 		},
 		"v1.9": {


### PR DESCRIPTION
https://github.com/rancher/rke/issues/765

MountPropagation=true is needed by the CSI plugin, CSI plugin or flexvolume plugin pods need mountpropagation equal to Bidirectional.

By default the mount propagation for any pod is None which is equivalent `private` on Linux systems, disabling mount propagation should have the same mount propagation for pod volumes `private`