### PR TITLE
Use secretName instead of secretId

### DIFF
--- a/apis/project.cattle.io/v3/schema/schema.go
+++ b/apis/project.cattle.io/v3/schema/schema.go
@@ -729,7 +729,6 @@ func volumeTypes(schemas *types.Schemas) *types.Schemas {
 			ClaimName string `norman:"type=reference[persistentVolumeClaim]"`
 		}{}).
 		MustImport(&Version, v1.SecretVolumeSource{}, struct {
-			SecretName string `norman:"type=reference[secret]"`
 		}{}).
 		MustImport(&Version, v1.VolumeMount{}, struct {
 			MountPath string `json:"mountPath" norman:"required"`

--- a/client/project/v3/zz_generated_secret_volume_source.go
+++ b/client/project/v3/zz_generated_secret_volume_source.go
@@ -5,12 +5,12 @@ const (
 	SecretVolumeSourceFieldDefaultMode = "defaultMode"
 	SecretVolumeSourceFieldItems       = "items"
 	SecretVolumeSourceFieldOptional    = "optional"
-	SecretVolumeSourceFieldSecretID    = "secretId"
+	SecretVolumeSourceFieldSecretName  = "secretName"
 )
 
 type SecretVolumeSource struct {
 	DefaultMode *int64      `json:"defaultMode,omitempty" yaml:"defaultMode,omitempty"`
 	Items       []KeyToPath `json:"items,omitempty" yaml:"items,omitempty"`
 	Optional    *bool       `json:"optional,omitempty" yaml:"optional,omitempty"`
-	SecretID    string      `json:"secretId,omitempty" yaml:"secretId,omitempty"`
+	SecretName  string      `json:"secretName,omitempty" yaml:"secretName,omitempty"`
 }


### PR DESCRIPTION
Using reference to id always returns `namespace:id`, but it doesn't
work while using project scoped secrets; thus using name similar
to secrets used in environment variables from source

https://github.com/rancher/rancher/issues/14740
https://github.com/rancher/rancher/issues/14368