### PR TITLE
Aks vnet options

### DIFF
--- a/apis/management.cattle.io/v3/cluster_types.go
+++ b/apis/management.cattle.io/v3/cluster_types.go
@@ -210,6 +210,10 @@ type AzureKubernetesServiceConfig struct {
 	Subnet string `json:"subnet,omitempty"`
 	// The resource group that the virtual network is in.  If omited it is assumed to match the resource group of the cluster
 	VirtualNetworkResourceGroup string `json:"virtualNetworkResourceGroup,omitempty"`
+	// Additional options for setting a custom virtual network
+	ServiceCIDR      string `json:"serviceCidr,omitempty"`
+	DNSServiceIP     string `json:"dnsServiceIp,omitempty"`
+	DockerBridgeCIDR string `json:"dockerBridgeCidr,omitempty"`
 }
 
 type AmazonElasticContainerServiceConfig struct {

--- a/client/management/v3/zz_generated_azure_kubernetes_service_config.go
+++ b/client/management/v3/zz_generated_azure_kubernetes_service_config.go
@@ -10,12 +10,15 @@ const (
 	AzureKubernetesServiceConfigFieldClientID                    = "clientId"
 	AzureKubernetesServiceConfigFieldClientSecret                = "clientSecret"
 	AzureKubernetesServiceConfigFieldCount                       = "count"
+	AzureKubernetesServiceConfigFieldDNSServiceIP                = "dnsServiceIp"
+	AzureKubernetesServiceConfigFieldDockerBridgeCIDR            = "dockerBridgeCidr"
 	AzureKubernetesServiceConfigFieldKubernetesVersion           = "kubernetesVersion"
 	AzureKubernetesServiceConfigFieldLocation                    = "location"
 	AzureKubernetesServiceConfigFieldMasterDNSPrefix             = "masterDnsPrefix"
 	AzureKubernetesServiceConfigFieldOsDiskSizeGB                = "osDiskSizeGb"
 	AzureKubernetesServiceConfigFieldResourceGroup               = "resourceGroup"
 	AzureKubernetesServiceConfigFieldSSHPublicKeyContents        = "sshPublicKeyContents"
+	AzureKubernetesServiceConfigFieldServiceCIDR                 = "serviceCidr"
 	AzureKubernetesServiceConfigFieldSubnet                      = "subnet"
 	AzureKubernetesServiceConfigFieldSubscriptionID              = "subscriptionId"
 	AzureKubernetesServiceConfigFieldTag                         = "tags"
@@ -33,12 +36,15 @@ type AzureKubernetesServiceConfig struct {
 	ClientID                    string            `json:"clientId,omitempty" yaml:"clientId,omitempty"`
 	ClientSecret                string            `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
 	Count                       int64             `json:"count,omitempty" yaml:"count,omitempty"`
+	DNSServiceIP                string            `json:"dnsServiceIp,omitempty" yaml:"dnsServiceIp,omitempty"`
+	DockerBridgeCIDR            string            `json:"dockerBridgeCidr,omitempty" yaml:"dockerBridgeCidr,omitempty"`
 	KubernetesVersion           string            `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
 	Location                    string            `json:"location,omitempty" yaml:"location,omitempty"`
 	MasterDNSPrefix             string            `json:"masterDnsPrefix,omitempty" yaml:"masterDnsPrefix,omitempty"`
 	OsDiskSizeGB                int64             `json:"osDiskSizeGb,omitempty" yaml:"osDiskSizeGb,omitempty"`
 	ResourceGroup               string            `json:"resourceGroup,omitempty" yaml:"resourceGroup,omitempty"`
 	SSHPublicKeyContents        string            `json:"sshPublicKeyContents,omitempty" yaml:"sshPublicKeyContents,omitempty"`
+	ServiceCIDR                 string            `json:"serviceCidr,omitempty" yaml:"serviceCidr,omitempty"`
 	Subnet                      string            `json:"subnet,omitempty" yaml:"subnet,omitempty"`
 	SubscriptionID              string            `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty"`
 	Tag                         map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`


### PR DESCRIPTION
Adding options to the AKS config so that options can be passed to support
setting a custom vnet (without these options, a cluster with a custom vnet
will not be functional).

Issue:
rancher/rancher#15135