### PR TITLE
Removed dnsLabel frm hostname prefix type

### DIFF
--- a/apis/management.cattle.io/v3/machine_types.go
+++ b/apis/management.cattle.io/v3/machine_types.go
@@ -144,7 +144,7 @@ type NodePoolSpec struct {
 	Worker           bool   `json:"worker"`
 	NodeTemplateName string `json:"nodeTemplateName,omitempty" norman:"type=reference[nodeTemplate],required,notnullable"`
 
-	HostnamePrefix  string            `json:"hostnamePrefix" norman:"type=dnsLabel,required,notnullable"`
+	HostnamePrefix  string            `json:"hostnamePrefix" norman:"required,notnullable"`
 	Quantity        int               `json:"quantity" norman:"required,default=1"`
 	NodeLabels      map[string]string `json:"nodeLabels"`
 	NodeAnnotations map[string]string `json:"nodeAnnotations"`


### PR DESCRIPTION
as it can end with "-" (so the name becomes `hostnameprefix-1`) - something that is not allowed by the dnsLabel format