### PR TITLE
fix regresssion for scheduling

### DIFF
--- a/mapper/scheduling.go
+++ b/mapper/scheduling.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	exprRegexp = regexp.MustCompile("^(.*?)\\s*(=|!=|<|>|in|notin)\\s*(.*)$")
+	exprRegexp = regexp.MustCompile("^(.*?)\\s*(=|!=|<|>| in | notin )\\s*(.*)$")
 )
 
 type SchedulingMapper struct {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/15379.
Fix the regression introduced by https://github.com/rancher/types/pull/535. We accidently remove the whitespace between in and notin.