### PR TITLE
Added support for SSH certificate authentication

### DIFF
--- a/apis/management.cattle.io/v3/machine_types.go
+++ b/apis/management.cattle.io/v3/machine_types.go
@@ -168,8 +168,10 @@ type CustomConfig struct {
 	// Optional - Docker socket on the node that will be used in tunneling
 	DockerSocket string `yaml:"docker_socket" json:"dockerSocket,omitempty"`
 	// SSH Private Key
-	SSHKey string            `yaml:"ssh_key" json:"sshKey,omitempty" norman:"type=password"`
-	Label  map[string]string `yaml:"label" json:"label,omitempty"`
+	SSHKey string `yaml:"ssh_key" json:"sshKey,omitempty" norman:"type=password"`
+	// SSH Certificate
+	SSHCert string            `yaml:"ssh_cert" json:"sshCert,omitempty"`
+	Label   map[string]string `yaml:"label" json:"label,omitempty"`
 }
 
 type NodeSpec struct {

--- a/apis/management.cattle.io/v3/rke_types.go
+++ b/apis/management.cattle.io/v3/rke_types.go
@@ -17,6 +17,8 @@ type RancherKubernetesEngineConfig struct {
 	SystemImages RKESystemImages `yaml:"system_images" json:"systemImages,omitempty"`
 	// SSH Private Key Path
 	SSHKeyPath string `yaml:"ssh_key_path" json:"sshKeyPath,omitempty"`
+	// SSH Certificate Path
+	SSHCertPath string `yaml:"ssh_cert_path" json:"sshCertPath,omitempty"`
 	// SSH Agent Auth enable
 	SSHAgentAuth bool `yaml:"ssh_agent_auth" json:"sshAgentAuth"`
 	// Authorization mode configuration used in the cluster
@@ -62,6 +64,10 @@ type BastionHost struct {
 	SSHKey string `yaml:"ssh_key" json:"sshKey,omitempty" norman:"type=password"`
 	// SSH Private Key Path
 	SSHKeyPath string `yaml:"ssh_key_path" json:"sshKeyPath,omitempty"`
+	// SSH Certificate
+	SSHCert string `yaml:"ssh_cert" json:"sshCert,omitempty"`
+	// SSH Certificate Path
+	SSHCertPath string `yaml:"ssh_cert_path" json:"sshCertPath,omitempty"`
 }
 
 type PrivateRegistry struct {
@@ -155,6 +161,10 @@ type RKEConfigNode struct {
 	SSHKey string `yaml:"ssh_key" json:"sshKey,omitempty" norman:"type=password"`
 	// SSH Private Key Path
 	SSHKeyPath string `yaml:"ssh_key_path" json:"sshKeyPath,omitempty"`
+	// SSH Certificate
+	SSHCert string `yaml:"ssh_cert" json:"sshCert,omitempty"`
+	// SSH Certificate Path
+	SSHCertPath string `yaml:"ssh_cert_path" json:"sshCertPath,omitempty"`
 	// Node Labels
 	Labels map[string]string `yaml:"labels" json:"labels,omitempty"`
 }

--- a/client/management/v3/zz_generated_bastion_host.go
+++ b/client/management/v3/zz_generated_bastion_host.go
@@ -5,6 +5,8 @@ const (
 	BastionHostFieldAddress      = "address"
 	BastionHostFieldPort         = "port"
 	BastionHostFieldSSHAgentAuth = "sshAgentAuth"
+	BastionHostFieldSSHCert      = "sshCert"
+	BastionHostFieldSSHCertPath  = "sshCertPath"
 	BastionHostFieldSSHKey       = "sshKey"
 	BastionHostFieldSSHKeyPath   = "sshKeyPath"
 	BastionHostFieldUser         = "user"
@@ -14,6 +16,8 @@ type BastionHost struct {
 	Address      string `json:"address,omitempty" yaml:"address,omitempty"`
 	Port         string `json:"port,omitempty" yaml:"port,omitempty"`
 	SSHAgentAuth bool   `json:"sshAgentAuth,omitempty" yaml:"sshAgentAuth,omitempty"`
+	SSHCert      string `json:"sshCert,omitempty" yaml:"sshCert,omitempty"`
+	SSHCertPath  string `json:"sshCertPath,omitempty" yaml:"sshCertPath,omitempty"`
 	SSHKey       string `json:"sshKey,omitempty" yaml:"sshKey,omitempty"`
 	SSHKeyPath   string `json:"sshKeyPath,omitempty" yaml:"sshKeyPath,omitempty"`
 	User         string `json:"user,omitempty" yaml:"user,omitempty"`

--- a/client/management/v3/zz_generated_custom_config.go
+++ b/client/management/v3/zz_generated_custom_config.go
@@ -6,6 +6,7 @@ const (
 	CustomConfigFieldDockerSocket    = "dockerSocket"
 	CustomConfigFieldInternalAddress = "internalAddress"
 	CustomConfigFieldLabel           = "label"
+	CustomConfigFieldSSHCert         = "sshCert"
 	CustomConfigFieldSSHKey          = "sshKey"
 	CustomConfigFieldUser            = "user"
 )
@@ -15,6 +16,7 @@ type CustomConfig struct {
 	DockerSocket    string            `json:"dockerSocket,omitempty" yaml:"dockerSocket,omitempty"`
 	InternalAddress string            `json:"internalAddress,omitempty" yaml:"internalAddress,omitempty"`
 	Label           map[string]string `json:"label,omitempty" yaml:"label,omitempty"`
+	SSHCert         string            `json:"sshCert,omitempty" yaml:"sshCert,omitempty"`
 	SSHKey          string            `json:"sshKey,omitempty" yaml:"sshKey,omitempty"`
 	User            string            `json:"user,omitempty" yaml:"user,omitempty"`
 }

--- a/client/management/v3/zz_generated_rancher_kubernetes_engine_config.go
+++ b/client/management/v3/zz_generated_rancher_kubernetes_engine_config.go
@@ -21,6 +21,7 @@ const (
 	RancherKubernetesEngineConfigFieldRestore             = "restore"
 	RancherKubernetesEngineConfigFieldRotateCertificates  = "rotateCertificates"
 	RancherKubernetesEngineConfigFieldSSHAgentAuth        = "sshAgentAuth"
+	RancherKubernetesEngineConfigFieldSSHCertPath         = "sshCertPath"
 	RancherKubernetesEngineConfigFieldSSHKeyPath          = "sshKeyPath"
 	RancherKubernetesEngineConfigFieldServices            = "services"
 	RancherKubernetesEngineConfigFieldVersion             = "kubernetesVersion"
@@ -46,6 +47,7 @@ type RancherKubernetesEngineConfig struct {
 	Restore             *RestoreConfig      `json:"restore,omitempty" yaml:"restore,omitempty"`
 	RotateCertificates  *RotateCertificates `json:"rotateCertificates,omitempty" yaml:"rotateCertificates,omitempty"`
 	SSHAgentAuth        bool                `json:"sshAgentAuth,omitempty" yaml:"sshAgentAuth,omitempty"`
+	SSHCertPath         string              `json:"sshCertPath,omitempty" yaml:"sshCertPath,omitempty"`
 	SSHKeyPath          string              `json:"sshKeyPath,omitempty" yaml:"sshKeyPath,omitempty"`
 	Services            *RKEConfigServices  `json:"services,omitempty" yaml:"services,omitempty"`
 	Version             string              `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`

--- a/client/management/v3/zz_generated_rke_config_node.go
+++ b/client/management/v3/zz_generated_rke_config_node.go
@@ -11,6 +11,8 @@ const (
 	RKEConfigNodeFieldPort             = "port"
 	RKEConfigNodeFieldRole             = "role"
 	RKEConfigNodeFieldSSHAgentAuth     = "sshAgentAuth"
+	RKEConfigNodeFieldSSHCert          = "sshCert"
+	RKEConfigNodeFieldSSHCertPath      = "sshCertPath"
 	RKEConfigNodeFieldSSHKey           = "sshKey"
 	RKEConfigNodeFieldSSHKeyPath       = "sshKeyPath"
 	RKEConfigNodeFieldUser             = "user"
@@ -26,6 +28,8 @@ type RKEConfigNode struct {
 	Port             string            `json:"port,omitempty" yaml:"port,omitempty"`
 	Role             []string          `json:"role,omitempty" yaml:"role,omitempty"`
 	SSHAgentAuth     bool              `json:"sshAgentAuth,omitempty" yaml:"sshAgentAuth,omitempty"`
+	SSHCert          string            `json:"sshCert,omitempty" yaml:"sshCert,omitempty"`
+	SSHCertPath      string            `json:"sshCertPath,omitempty" yaml:"sshCertPath,omitempty"`
 	SSHKey           string            `json:"sshKey,omitempty" yaml:"sshKey,omitempty"`
 	SSHKeyPath       string            `json:"sshKeyPath,omitempty" yaml:"sshKeyPath,omitempty"`
 	User             string            `json:"user,omitempty" yaml:"user,omitempty"`


### PR DESCRIPTION
## What does this do

Add support for SSH certificates when using RKE. 

RKE fork that relies on changes: 
https://github.com/bernard-wagner/rke/tree/ssh-cert

For more background:

https://man.openbsd.org/ssh-keygen.1#CERTIFICATES
https://man.openbsd.org/sshd_config#TrustedUserCAKeys

## How it was tested

### Created CA

```
$ ssh-keygen -t rsa -b 4096 -f demo-ca -q -P ""
$ cat demo-ca.pub
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXoifoWpZ/SC5bzOSmBmCRJMM4lF2....
```

### Provisioned CoreOS Node with following cloud-config:

```
storage:
  files:
    - filesystem: root
      user: 
        name: root
      group: 
        name: root
      path: /etc/ssh/ssh_trusted_user_ca_keys
      mode: 0644
      contents: 
        inline: |
          ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXoifoWpZ/SC5bzOSmBmCRJMM4lF2....
    - filesystem: root
      path: /etc/ssh/sshd_config
      contents: 
        inline: |
          UsePrivilegeSeparation sandbox
          Subsystem sftp internal-sftp
          UseDNS no

          PermitRootLogin no
          AllowUsers core
          AuthenticationMethods publickey        
          TrustedUserCAKeys /etc/ssh/ssh_trusted_user_ca_keys
```

### Created New KeyPair 
```
$ ssh-keygen -f test-key -q -P ""
```

### Signed KeyPair

```
$ ssh-keygen -s demo-ca -I TEST -n core -V +2h test-key.pub
```

### Init Cluster (cluster.yml)
```
nodes:
    - address: 192.168.56.101
      port: 22
      user: core
      role:
        - controlplane
        - etcd
        - worker
      ssh_key_path: ./test-key
      ssh_cert_path: ./test-key-cert.pub
    
ignore_docker_version: true    
```
### Node with inline certificate:

```
nodes:
    - address: 192.168.56.101
      port: 22
      user: core
      role:
        - controlplane
        - etcd
        - worker
      ssh_key_path: ./test-key
      ssh_cert: |-
        ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3Bl
         
ignore_docker_version: true    
```
### Bastion Test with authorized_keys (cluster.yml)

Reinitialized host and added another with a preconfigured authorized_keys file:
```
nodes:
  - address: 192.168.56.102
    port: 22
    user: core
    role:
      - controlplane
      - etcd
      - worker
    ssh_key: |-
      -----BEGIN RSA PRIVATE KEY-----
      .....
      -----END RSA PRIVATE KEY-----

bastion_host:
    address: 192.168.56.101
    user: core
    port: 22
    ssh_key_path: ./test-key
    ssh_cert_path: ./test-key-cert.pub

ignore_docker_version: true    
```


### Bastion Test with Certificates (cluster.yml)

Reinitialized host and added another with a preconfigured authorized_keys file:
```
nodes:
  - address: 192.168.56.102
    port: 22
    user: core
    role:
      - controlplane
      - etcd
      - worker
    ssh_key_path: ./test-key
    ssh_cert_path: ./test-key-cert.pub

bastion_host:
    address: 192.168.56.101
    user: core
    port: 22
    ssh_key_path: ./test-key
    ssh_cert_path: ./test-key-cert.pub

ignore_docker_version: true    
```
