### PR TITLE
Add method to get cluster/project members that are groups

### DIFF
--- a/user/manager.go
+++ b/user/manager.go
@@ -14,4 +14,5 @@ type Manager interface {
 	CheckAccess(accessMode string, allowedPrincipalIDs []string, user v3.Principal, groups []v3.Principal) (bool, error)
 	SetPrincipalOnCurrentUserByUserID(userID string, principal v3.Principal) (*v3.User, error)
 	CreateNewUserClusterRoleBinding(userName string, userUID apitypes.UID) error
+	GetGroupsFromClustersAndProjects() ([]string, error)
 }


### PR DESCRIPTION
This method is used for Active Directory nested group search