### PR TITLE
Add RKEConfigService to RKEConfigNode

### DIFF
--- a/apis/management.cattle.io/v3/rke_types.go
+++ b/apis/management.cattle.io/v3/rke_types.go
@@ -147,6 +147,8 @@ type RKEConfigNode struct {
 	SSHKeyPath string `yaml:"ssh_key_path" json:"sshKeyPath,omitempty"`
 	// Node Labels
 	Labels map[string]string `yaml:"labels" json:"labels,omitempty"`
+	// Kubernetes components
+	Services RKEConfigServices `yaml:"services" json:"services,omitempty"`
 }
 
 type RKEConfigServices struct {

--- a/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -4907,6 +4907,7 @@ func (in *RKEConfigNode) DeepCopyInto(out *RKEConfigNode) {
 			(*out)[key] = val
 		}
 	}
+	in.Services.DeepCopyInto(&out.Services)
 	return
 }
 

--- a/client/management/v3/zz_generated_rke_config_node.go
+++ b/client/management/v3/zz_generated_rke_config_node.go
@@ -13,20 +13,22 @@ const (
 	RKEConfigNodeFieldSSHAgentAuth     = "sshAgentAuth"
 	RKEConfigNodeFieldSSHKey           = "sshKey"
 	RKEConfigNodeFieldSSHKeyPath       = "sshKeyPath"
+	RKEConfigNodeFieldServices         = "services"
 	RKEConfigNodeFieldUser             = "user"
 )
 
 type RKEConfigNode struct {
-	Address          string            `json:"address,omitempty" yaml:"address,omitempty"`
-	DockerSocket     string            `json:"dockerSocket,omitempty" yaml:"dockerSocket,omitempty"`
-	HostnameOverride string            `json:"hostnameOverride,omitempty" yaml:"hostnameOverride,omitempty"`
-	InternalAddress  string            `json:"internalAddress,omitempty" yaml:"internalAddress,omitempty"`
-	Labels           map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	NodeID           string            `json:"nodeId,omitempty" yaml:"nodeId,omitempty"`
-	Port             string            `json:"port,omitempty" yaml:"port,omitempty"`
-	Role             []string          `json:"role,omitempty" yaml:"role,omitempty"`
-	SSHAgentAuth     bool              `json:"sshAgentAuth,omitempty" yaml:"sshAgentAuth,omitempty"`
-	SSHKey           string            `json:"sshKey,omitempty" yaml:"sshKey,omitempty"`
-	SSHKeyPath       string            `json:"sshKeyPath,omitempty" yaml:"sshKeyPath,omitempty"`
-	User             string            `json:"user,omitempty" yaml:"user,omitempty"`
+	Address          string             `json:"address,omitempty" yaml:"address,omitempty"`
+	DockerSocket     string             `json:"dockerSocket,omitempty" yaml:"dockerSocket,omitempty"`
+	HostnameOverride string             `json:"hostnameOverride,omitempty" yaml:"hostnameOverride,omitempty"`
+	InternalAddress  string             `json:"internalAddress,omitempty" yaml:"internalAddress,omitempty"`
+	Labels           map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty"`
+	NodeID           string             `json:"nodeId,omitempty" yaml:"nodeId,omitempty"`
+	Port             string             `json:"port,omitempty" yaml:"port,omitempty"`
+	Role             []string           `json:"role,omitempty" yaml:"role,omitempty"`
+	SSHAgentAuth     bool               `json:"sshAgentAuth,omitempty" yaml:"sshAgentAuth,omitempty"`
+	SSHKey           string             `json:"sshKey,omitempty" yaml:"sshKey,omitempty"`
+	SSHKeyPath       string             `json:"sshKeyPath,omitempty" yaml:"sshKeyPath,omitempty"`
+	Services         *RKEConfigServices `json:"services,omitempty" yaml:"services,omitempty"`
+	User             string             `json:"user,omitempty" yaml:"user,omitempty"`
 }


### PR DESCRIPTION
In order to allow the user to override kube-proxy, kubelet command
arguments by extra_args for each node, we need to introduce RKEConfigService to RKEConfigNode.

This commit is need to implement following feature requests in rke
https://github.com/rancher/rke/issues/938