### PR TITLE
Eks Session token for Assume Role

### DIFF
--- a/apis/management.cattle.io/v3/cluster_types.go
+++ b/apis/management.cattle.io/v3/cluster_types.go
@@ -217,8 +217,9 @@ type AzureKubernetesServiceConfig struct {
 }
 
 type AmazonElasticContainerServiceConfig struct {
-	AccessKey string `json:"accessKey" norman:"required"`
-	SecretKey string `json:"secretKey" norman:"required,type=password"`
+	AccessKey    string `json:"accessKey" norman:"required"`
+	SecretKey    string `json:"secretKey" norman:"required,type=password"`
+	SessionToken string `json:"sessionToken,omitempty" norman:"type=password"`
 
 	Region                      string   `json:"region"`
 	InstanceType                string   `json:"instanceType"`

--- a/client/management/v3/zz_generated_amazon_elastic_container_service_config.go
+++ b/client/management/v3/zz_generated_amazon_elastic_container_service_config.go
@@ -12,6 +12,7 @@ const (
 	AmazonElasticContainerServiceConfigFieldSecretKey                   = "secretKey"
 	AmazonElasticContainerServiceConfigFieldSecurityGroups              = "securityGroups"
 	AmazonElasticContainerServiceConfigFieldServiceRole                 = "serviceRole"
+	AmazonElasticContainerServiceConfigFieldSessionToken                = "sessionToken"
 	AmazonElasticContainerServiceConfigFieldSubnets                     = "subnets"
 	AmazonElasticContainerServiceConfigFieldVirtualNetwork              = "virtualNetwork"
 )
@@ -27,6 +28,7 @@ type AmazonElasticContainerServiceConfig struct {
 	SecretKey                   string   `json:"secretKey,omitempty" yaml:"secretKey,omitempty"`
 	SecurityGroups              []string `json:"securityGroups,omitempty" yaml:"securityGroups,omitempty"`
 	ServiceRole                 string   `json:"serviceRole,omitempty" yaml:"serviceRole,omitempty"`
+	SessionToken                string   `json:"sessionToken,omitempty" yaml:"sessionToken,omitempty"`
 	Subnets                     []string `json:"subnets,omitempty" yaml:"subnets,omitempty"`
 	VirtualNetwork              string   `json:"virtualNetwork,omitempty" yaml:"virtualNetwork,omitempty"`
 }


### PR DESCRIPTION
This change adds a session token field to the eks config to support
provisioning clusters with credentials generated via GetSessionToken or
AssumeRole calls.

Issue:
rancher/rancher#16005