### PR TITLE
Remove DefaultK8s param, no longer needed

### DIFF
--- a/apis/management.cattle.io/v3/k8s_defaults.go
+++ b/apis/management.cattle.io/v3/k8s_defaults.go
@@ -8,10 +8,6 @@ import (
 	"github.com/rancher/types/image"
 )
 
-const (
-	DefaultK8s = "v1.12.1-rancher1-1"
-)
-
 var (
 	m = image.Mirror
 
@@ -613,10 +609,6 @@ func init() {
 			panic("K8s version " + " is not found in AllK8sVersions map")
 		}
 		K8sVersionToRKESystemImages[latest] = images
-	}
-
-	if _, ok := K8sVersionToRKESystemImages[DefaultK8s]; !ok {
-		panic("Default K8s version " + DefaultK8s + " is not found in k8sVersionsCurrent list")
 	}
 
 	// init Windows versions

--- a/apis/management.cattle.io/v3/k8s_windows_default.go
+++ b/apis/management.cattle.io/v3/k8s_windows_default.go
@@ -235,7 +235,4 @@ func initWindows() {
 		K8sVersionWindowsSystemImages[version] = images
 	}
 
-	if _, ok := K8sVersionWindowsSystemImages[DefaultK8s]; !ok {
-		panic("Default K8s version " + DefaultK8s + " is not found in k8sVersionsCurrent list")
-	}
 }


### PR DESCRIPTION
rancher/rancher#16572 adds two new fields to settings which are both semver ranges for valid k8s versions
`DefaultK8s` was no longer used by the UI and after some discussion with Vince and Craig it was deemed that it no longer makes sense to keep this parameter in rancher. 

rancher/rancher#16113