### PR TITLE
Not omit threshold field

### DIFF
--- a/apis/management.cattle.io/v3/alerting_types.go
+++ b/apis/management.cattle.io/v3/alerting_types.go
@@ -200,12 +200,10 @@ type CommonRuleField struct {
 
 type MetricRule struct {
 	Expression     string  `json:"expression,omitempty" norman:"required"`
-	LegendFormat   string  `json:"legendFormat,omitempty"`
-	Step           int64   `json:"step,omitempty"`
 	Description    string  `json:"description,omitempty"`
-	Duration       string  `json:"duration,omitempty"`
+	Duration       string  `json:"duration,omitempty" norman:"required"`
 	Comparison     string  `json:"comparison,omitempty" norman:"type=enum,options=equal|not-equal|greater-than|less-than|greater-or-equal|less-or-equal,default=equal"`
-	ThresholdValue float64 `json:"thresholdValue,omitempty" norman:"type=float"`
+	ThresholdValue float64 `json:"thresholdValue,omitempty" norman:"required,type=float"`
 }
 
 type TimingField struct {

--- a/client/management/v3/zz_generated_metric_rule.go
+++ b/client/management/v3/zz_generated_metric_rule.go
@@ -6,8 +6,6 @@ const (
 	MetricRuleFieldDescription    = "description"
 	MetricRuleFieldDuration       = "duration"
 	MetricRuleFieldExpression     = "expression"
-	MetricRuleFieldLegendFormat   = "legendFormat"
-	MetricRuleFieldStep           = "step"
 	MetricRuleFieldThresholdValue = "thresholdValue"
 )
 
@@ -16,7 +14,5 @@ type MetricRule struct {
 	Description    string  `json:"description,omitempty" yaml:"description,omitempty"`
 	Duration       string  `json:"duration,omitempty" yaml:"duration,omitempty"`
 	Expression     string  `json:"expression,omitempty" yaml:"expression,omitempty"`
-	LegendFormat   string  `json:"legendFormat,omitempty" yaml:"legendFormat,omitempty"`
-	Step           int64   `json:"step,omitempty" yaml:"step,omitempty"`
 	ThresholdValue float64 `json:"thresholdValue,omitempty" yaml:"thresholdValue,omitempty"`
 }


### PR DESCRIPTION
Problem:
1. default value for float return zero string
2. we need threshold value to build alert expression, 0 is useful value

Solution:
1. fix float type default value in norman
2. not omit threshold value

Norman:
https://github.com/rancher/norman/pull/237