### PR TITLE
Secrets encryption config

### DIFF
--- a/apis/management.cattle.io/v3/k8s_defaults.go
+++ b/apis/management.cattle.io/v3/k8s_defaults.go
@@ -36,8 +36,9 @@ var (
 	K8sVersionServiceOptions = map[string]KubernetesServicesOptions{
 		"v1.13": {
 			KubeAPI: map[string]string{
-				"tls-cipher-suites":        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-				"enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
+				"tls-cipher-suites":          "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+				"enable-admission-plugins":   "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
+				"encryption-provider-config": "/etc/kubernetes/encryption.yaml",
 			},
 			Kubelet: map[string]string{
 				"tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
@@ -45,8 +46,9 @@ var (
 		},
 		"v1.12": {
 			KubeAPI: map[string]string{
-				"tls-cipher-suites":        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-				"enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
+				"tls-cipher-suites":                       "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+				"enable-admission-plugins":                "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
+				"experimental-encryption-provider-config": "/etc/kubernetes/encryption.yaml",
 			},
 			Kubelet: map[string]string{
 				"tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
@@ -54,8 +56,9 @@ var (
 		},
 		"v1.11": {
 			KubeAPI: map[string]string{
-				"tls-cipher-suites":        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-				"enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
+				"tls-cipher-suites":                       "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+				"enable-admission-plugins":                "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
+				"experimental-encryption-provider-config": "/etc/kubernetes/encryption.yaml",
 			},
 			Kubelet: map[string]string{
 				"tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
@@ -64,9 +67,10 @@ var (
 		},
 		"v1.10": {
 			KubeAPI: map[string]string{
-				"tls-cipher-suites":        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-				"endpoint-reconciler-type": "lease",
-				"enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
+				"tls-cipher-suites":                       "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+				"endpoint-reconciler-type":                "lease",
+				"enable-admission-plugins":                "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota",
+				"experimental-encryption-provider-config": "/etc/kubernetes/encryption.yaml",
 			},
 			Kubelet: map[string]string{
 				"tls-cipher-suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
@@ -75,8 +79,9 @@ var (
 		},
 		"v1.9": {
 			KubeAPI: map[string]string{
-				"endpoint-reconciler-type": "lease",
-				"admission-control":        "ServiceAccount,NamespaceLifecycle,LimitRanger,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds",
+				"endpoint-reconciler-type":                "lease",
+				"admission-control":                       "ServiceAccount,NamespaceLifecycle,LimitRanger,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds",
+				"experimental-encryption-provider-config": "/etc/kubernetes/encryption.yaml",
 			},
 			Kubelet: map[string]string{
 				"cadvisor-port": "0",

--- a/apis/management.cattle.io/v3/rke_types.go
+++ b/apis/management.cattle.io/v3/rke_types.go
@@ -218,6 +218,8 @@ type KubeAPIService struct {
 	PodSecurityPolicy bool `yaml:"pod_security_policy" json:"podSecurityPolicy,omitempty"`
 	// Enable/Disable AlwaysPullImages admissions plugin
 	AlwaysPullImages bool `yaml:"always_pull_images" json:"always_pull_images,omitempty"`
+	// Configuration for secrets encryption provider. https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#understanding-the-encryption-at-rest-configuration
+	SecretsEncryptionConfig string `yaml:"secrets_encryption_config" json:"secretsEncryptionConfig,omitempty"`
 }
 
 type KubeControllerService struct {

--- a/client/management/v3/zz_generated_kube_apiservice.go
+++ b/client/management/v3/zz_generated_kube_apiservice.go
@@ -1,24 +1,26 @@
 package client
 
 const (
-	KubeAPIServiceType                       = "kubeAPIService"
-	KubeAPIServiceFieldAlwaysPullImages      = "always_pull_images"
-	KubeAPIServiceFieldExtraArgs             = "extraArgs"
-	KubeAPIServiceFieldExtraBinds            = "extraBinds"
-	KubeAPIServiceFieldExtraEnv              = "extraEnv"
-	KubeAPIServiceFieldImage                 = "image"
-	KubeAPIServiceFieldPodSecurityPolicy     = "podSecurityPolicy"
-	KubeAPIServiceFieldServiceClusterIPRange = "serviceClusterIpRange"
-	KubeAPIServiceFieldServiceNodePortRange  = "serviceNodePortRange"
+	KubeAPIServiceType                         = "kubeAPIService"
+	KubeAPIServiceFieldAlwaysPullImages        = "always_pull_images"
+	KubeAPIServiceFieldExtraArgs               = "extraArgs"
+	KubeAPIServiceFieldExtraBinds              = "extraBinds"
+	KubeAPIServiceFieldExtraEnv                = "extraEnv"
+	KubeAPIServiceFieldImage                   = "image"
+	KubeAPIServiceFieldPodSecurityPolicy       = "podSecurityPolicy"
+	KubeAPIServiceFieldSecretsEncryptionConfig = "secretsEncryptionConfig"
+	KubeAPIServiceFieldServiceClusterIPRange   = "serviceClusterIpRange"
+	KubeAPIServiceFieldServiceNodePortRange    = "serviceNodePortRange"
 )
 
 type KubeAPIService struct {
-	AlwaysPullImages      bool              `json:"always_pull_images,omitempty" yaml:"always_pull_images,omitempty"`
-	ExtraArgs             map[string]string `json:"extraArgs,omitempty" yaml:"extraArgs,omitempty"`
-	ExtraBinds            []string          `json:"extraBinds,omitempty" yaml:"extraBinds,omitempty"`
-	ExtraEnv              []string          `json:"extraEnv,omitempty" yaml:"extraEnv,omitempty"`
-	Image                 string            `json:"image,omitempty" yaml:"image,omitempty"`
-	PodSecurityPolicy     bool              `json:"podSecurityPolicy,omitempty" yaml:"podSecurityPolicy,omitempty"`
-	ServiceClusterIPRange string            `json:"serviceClusterIpRange,omitempty" yaml:"serviceClusterIpRange,omitempty"`
-	ServiceNodePortRange  string            `json:"serviceNodePortRange,omitempty" yaml:"serviceNodePortRange,omitempty"`
+	AlwaysPullImages        bool              `json:"always_pull_images,omitempty" yaml:"always_pull_images,omitempty"`
+	ExtraArgs               map[string]string `json:"extraArgs,omitempty" yaml:"extraArgs,omitempty"`
+	ExtraBinds              []string          `json:"extraBinds,omitempty" yaml:"extraBinds,omitempty"`
+	ExtraEnv                []string          `json:"extraEnv,omitempty" yaml:"extraEnv,omitempty"`
+	Image                   string            `json:"image,omitempty" yaml:"image,omitempty"`
+	PodSecurityPolicy       bool              `json:"podSecurityPolicy,omitempty" yaml:"podSecurityPolicy,omitempty"`
+	SecretsEncryptionConfig string            `json:"secretsEncryptionConfig,omitempty" yaml:"secretsEncryptionConfig,omitempty"`
+	ServiceClusterIPRange   string            `json:"serviceClusterIpRange,omitempty" yaml:"serviceClusterIpRange,omitempty"`
+	ServiceNodePortRange    string            `json:"serviceNodePortRange,omitempty" yaml:"serviceNodePortRange,omitempty"`
 }


### PR DESCRIPTION
Add option to define the secrets encryption config and kube-apiserver option to enable the config.  

Note: this option changes from  `--experimental-encryption-provider-config` to `--encryption-provider-config` in k8s 1.13.