### PR TITLE
Update Ingress controller version

### DIFF
--- a/apis/management.cattle.io/v3/k8s_defaults.go
+++ b/apis/management.cattle.io/v3/k8s_defaults.go
@@ -769,7 +769,7 @@ var (
 			WeaveNode:                 m("weaveworks/weave-kube:2.5.0"),
 			WeaveCNI:                  m("weaveworks/weave-npc:2.5.0"),
 			PodInfraContainer:         m("gcr.io/google_containers/pause-amd64:3.1"),
-			Ingress:                   m("rancher/nginx-ingress-controller:0.16.2-rancher1"),
+			Ingress:                   m("rancher/nginx-ingress-controller:0.21.0-rancher1"),
 			IngressBackend:            m("k8s.gcr.io/defaultbackend:1.4"),
 			MetricsServer:             m("gcr.io/google_containers/metrics-server-amd64:v0.3.1"),
 		},


### PR DESCRIPTION
Related issue https://github.com/rancher/rancher/issues/15163
For k8s v1.12.3-rancher1-1, update ingress to 0.21.0-rancher1

Waiting for new Ingress controller image being built and pushed