### PR TITLE
Support local chart app upgrade & rollback

### DIFF
--- a/apis/management.cattle.io/v3/catalog_types.go
+++ b/apis/management.cattle.io/v3/catalog_types.go
@@ -3,7 +3,6 @@ package v3
 import (
 	"github.com/rancher/norman/condition"
 	"github.com/rancher/norman/types"
-
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/apis/project.cattle.io/v3/app_types.go
+++ b/apis/project.cattle.io/v3/app_types.go
@@ -75,6 +75,7 @@ type AppRevisionStatus struct {
 	Answers     map[string]string `json:"answers"`
 	Digest      string            `json:"digest"`
 	ValuesYaml  string            `json:"valuesYaml,omitempty"`
+	Files       map[string]string `json:"files,omitempty"`
 }
 
 type AppUpgradeConfig struct {

--- a/apis/project.cattle.io/v3/app_types.go
+++ b/apis/project.cattle.io/v3/app_types.go
@@ -81,6 +81,7 @@ type AppUpgradeConfig struct {
 	ExternalID   string            `json:"externalId,omitempty"`
 	Answers      map[string]string `json:"answers,omitempty"`
 	ForceUpgrade bool              `json:"forceUpgrade,omitempty"`
+	Files        map[string]string `json:"files,omitempty"`
 }
 
 type RollbackRevision struct {

--- a/apis/project.cattle.io/v3/zz_generated_deepcopy.go
+++ b/apis/project.cattle.io/v3/zz_generated_deepcopy.go
@@ -170,6 +170,13 @@ func (in *AppRevisionStatus) DeepCopyInto(out *AppRevisionStatus) {
 			(*out)[key] = val
 		}
 	}
+	if in.Files != nil {
+		in, out := &in.Files, &out.Files
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 
@@ -246,6 +253,13 @@ func (in *AppUpgradeConfig) DeepCopyInto(out *AppUpgradeConfig) {
 	*out = *in
 	if in.Answers != nil {
 		in, out := &in.Answers, &out.Answers
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Files != nil {
+		in, out := &in.Files, &out.Files
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/client/project/v3/zz_generated_app_revision_status.go
+++ b/client/project/v3/zz_generated_app_revision_status.go
@@ -5,6 +5,7 @@ const (
 	AppRevisionStatusFieldAnswers    = "answers"
 	AppRevisionStatusFieldDigest     = "digest"
 	AppRevisionStatusFieldExternalID = "externalId"
+	AppRevisionStatusFieldFiles      = "files"
 	AppRevisionStatusFieldProjectID  = "projectId"
 	AppRevisionStatusFieldValuesYaml = "valuesYaml"
 )
@@ -13,6 +14,7 @@ type AppRevisionStatus struct {
 	Answers    map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
 	Digest     string            `json:"digest,omitempty" yaml:"digest,omitempty"`
 	ExternalID string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
+	Files      map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
 	ProjectID  string            `json:"projectId,omitempty" yaml:"projectId,omitempty"`
 	ValuesYaml string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
 }

--- a/client/project/v3/zz_generated_app_upgrade_config.go
+++ b/client/project/v3/zz_generated_app_upgrade_config.go
@@ -4,11 +4,13 @@ const (
 	AppUpgradeConfigType              = "appUpgradeConfig"
 	AppUpgradeConfigFieldAnswers      = "answers"
 	AppUpgradeConfigFieldExternalID   = "externalId"
+	AppUpgradeConfigFieldFiles        = "files"
 	AppUpgradeConfigFieldForceUpgrade = "forceUpgrade"
 )
 
 type AppUpgradeConfig struct {
 	Answers      map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
 	ExternalID   string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
+	Files        map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
 	ForceUpgrade bool              `json:"forceUpgrade,omitempty" yaml:"forceUpgrade,omitempty"`
 }


### PR DESCRIPTION
**Problem:**
- Cannot upgrade local chart app
- Cannot rollback local chart app

**Solution:**
- Add `Files` field to `AppUpgradeConfig`
- Add `Files` field to `AppRevisionStatus` to record local chart templates

**Issue:**
rancher/rancher#15711