### PR TITLE
Remove 1.9/1.10 k8s versions

### DIFF
--- a/apis/management.cattle.io/v3/k8s_defaults.go
+++ b/apis/management.cattle.io/v3/k8s_defaults.go
@@ -9,18 +9,22 @@ import (
 )
 
 const (
-	DefaultK8s = "v1.12.4-rancher1-1"
+	DefaultK8s = "v1.13.1-rancher1-1"
 )
 
 var (
 	m = image.Mirror
 
-	// k8sVersionsCurrent are the latest versions available for installation
-	k8sVersionsCurrent = []string{
-		"v1.9.7-rancher2-2",
-		"v1.10.12-rancher1-1",
+	K8sBadVersions = map[string]bool{
+		"v1.9.7-rancher1":    true,
+		"v1.10.1-rancher1":   true,
+		"v1.8.11-rancher1":   true,
+		"v1.8.10-rancher1-1": true,
+	}
+
+	// K8sVersionsCurrent are the latest versions available for installation
+	K8sVersionsCurrent = []string{
 		"v1.11.6-rancher1-1",
-		"v1.12.4-rancher1-1",
 		"v1.12.5-rancher1-1",
 		"v1.13.1-rancher1-1",
 	}
@@ -815,13 +819,6 @@ var (
 )
 
 func init() {
-	badVersions := map[string]bool{
-		"v1.9.7-rancher1":    true,
-		"v1.10.1-rancher1":   true,
-		"v1.8.11-rancher1":   true,
-		"v1.8.10-rancher1-1": true,
-	}
-
 	if K8sVersionToRKESystemImages != nil {
 		panic("Do not initialize or add values to K8sVersionToRKESystemImages")
 	}
@@ -829,7 +826,7 @@ func init() {
 	K8sVersionToRKESystemImages = map[string]RKESystemImages{}
 
 	for version, images := range AllK8sVersions {
-		if badVersions[version] {
+		if K8sBadVersions[version] {
 			continue
 		}
 
@@ -839,7 +836,7 @@ func init() {
 		}
 	}
 
-	for _, latest := range k8sVersionsCurrent {
+	for _, latest := range K8sVersionsCurrent {
 		images, ok := AllK8sVersions[latest]
 		if !ok {
 			panic("K8s version " + " is not found in AllK8sVersions map")


### PR DESCRIPTION
Remove K8s 1.9 and 1.10 from supported version. https://github.com/rancher/rke/issues/1075

Change badVersions and k8sVersionsCurrent to exported variables so RKE can use them to determine valid versions. RKE needs to allow more than just K8sVersionCurrent list. https://github.com/rancher/rke/issues/1049, https://github.com/rancher/rke/issues/921