### PR TITLE
Update catalog types for disk caching

### DIFF
--- a/apis/management.cattle.io/v3/catalog_types.go
+++ b/apis/management.cattle.io/v3/catalog_types.go
@@ -36,8 +36,9 @@ type CatalogStatus struct {
 }
 
 var (
-	CatalogConditionRefreshed condition.Cond = "Refreshed"
-	CatalogConditionUpgraded  condition.Cond = "Upgraded"
+	CatalogConditionRefreshed  condition.Cond = "Refreshed"
+	CatalogConditionUpgraded   condition.Cond = "Upgraded"
+	CatalogConditionDiskCached condition.Cond = "DiskCached"
 )
 
 type CatalogCondition struct {
@@ -100,7 +101,9 @@ type TemplateSpec struct {
 	FolderName     string `json:"folderName,omitempty"`
 	Icon           string `json:"icon,omitempty"`
 	IconFilename   string `json:"iconFilename,omitempty"`
-	Readme         string `json:"readme,omitempty"`
+
+	// Deprecated: Do not use
+	Readme string `json:"readme,omitempty" norman:"nocreate,noupdate"`
 
 	Categories []string              `json:"categories,omitempty"`
 	Versions   []TemplateVersionSpec `json:"versions,omitempty"`
@@ -137,15 +140,24 @@ type TemplateVersionSpec struct {
 	ExternalID          string            `json:"externalId,omitempty"`
 	Version             string            `json:"version,omitempty"`
 	RancherVersion      string            `json:"rancherVersion,omitempty"`
+	RequiredNamespace   string            `json:"requiredNamespace,omitempty"`
 	KubeVersion         string            `json:"kubeVersion,omitempty"`
-	Readme              string            `json:"readme,omitempty"`
-	AppReadme           string            `json:"appReadme,omitempty"`
 	UpgradeVersionLinks map[string]string `json:"upgradeVersionLinks,omitempty"`
 	Digest              string            `json:"digest,omitempty"`
 
-	Files             map[string]string `json:"files,omitempty"`
-	Questions         []Question        `json:"questions,omitempty"`
-	RequiredNamespace string            `json:"requiredNamespace,omitempty"`
+	// Deprecated: Do not use
+	Files map[string]string `json:"files,omitempty" norman:"nocreate,noupdate"`
+	// Deprecated: Do not use
+	Questions []Question `json:"questions,omitempty" norman:"nocreate,noupdate"`
+	// Deprecated: Do not use
+	Readme string `json:"readme,omitempty" norman:"nocreate,noupdate"`
+	// Deprecated: Do not use
+	AppReadme string `json:"appReadme,omitempty" norman:"nocreate,noupdate"`
+
+	// for local cache rebuilt
+	VersionName string   `json:"versionName,omitempty"`
+	VersionDir  string   `json:"versionDir,omitempty"`
+	VersionURLs []string `json:"versionUrls,omitempty"`
 }
 
 type TemplateVersionStatus struct {
@@ -194,6 +206,9 @@ type SubQuestion struct {
 	ShowIf       string   `json:"showIf,omitempty" yaml:"show_if,omitempty"`
 }
 
+// TemplateContent is deprecated
+//
+// Deprecated: Do not use
 type TemplateContent struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object’s metadata. More info:

--- a/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -8103,6 +8103,11 @@ func (in *TemplateVersionSpec) DeepCopyInto(out *TemplateVersionSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.VersionURLs != nil {
+		in, out := &in.VersionURLs, &out.VersionURLs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/client/management/v3/zz_generated_catalog_template_version.go
+++ b/client/management/v3/zz_generated_catalog_template_version.go
@@ -29,6 +29,9 @@ const (
 	CatalogTemplateVersionFieldUUID                 = "uuid"
 	CatalogTemplateVersionFieldUpgradeVersionLinks  = "upgradeVersionLinks"
 	CatalogTemplateVersionFieldVersion              = "version"
+	CatalogTemplateVersionFieldVersionDir           = "versionDir"
+	CatalogTemplateVersionFieldVersionName          = "versionName"
+	CatalogTemplateVersionFieldVersionURLs          = "versionUrls"
 )
 
 type CatalogTemplateVersion struct {
@@ -56,6 +59,9 @@ type CatalogTemplateVersion struct {
 	UUID                 string                 `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 	UpgradeVersionLinks  map[string]string      `json:"upgradeVersionLinks,omitempty" yaml:"upgradeVersionLinks,omitempty"`
 	Version              string                 `json:"version,omitempty" yaml:"version,omitempty"`
+	VersionDir           string                 `json:"versionDir,omitempty" yaml:"versionDir,omitempty"`
+	VersionName          string                 `json:"versionName,omitempty" yaml:"versionName,omitempty"`
+	VersionURLs          []string               `json:"versionUrls,omitempty" yaml:"versionUrls,omitempty"`
 }
 
 type CatalogTemplateVersionCollection struct {

--- a/client/management/v3/zz_generated_template_version.go
+++ b/client/management/v3/zz_generated_template_version.go
@@ -29,6 +29,9 @@ const (
 	TemplateVersionFieldUUID                 = "uuid"
 	TemplateVersionFieldUpgradeVersionLinks  = "upgradeVersionLinks"
 	TemplateVersionFieldVersion              = "version"
+	TemplateVersionFieldVersionDir           = "versionDir"
+	TemplateVersionFieldVersionName          = "versionName"
+	TemplateVersionFieldVersionURLs          = "versionUrls"
 )
 
 type TemplateVersion struct {
@@ -56,6 +59,9 @@ type TemplateVersion struct {
 	UUID                 string                 `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 	UpgradeVersionLinks  map[string]string      `json:"upgradeVersionLinks,omitempty" yaml:"upgradeVersionLinks,omitempty"`
 	Version              string                 `json:"version,omitempty" yaml:"version,omitempty"`
+	VersionDir           string                 `json:"versionDir,omitempty" yaml:"versionDir,omitempty"`
+	VersionName          string                 `json:"versionName,omitempty" yaml:"versionName,omitempty"`
+	VersionURLs          []string               `json:"versionUrls,omitempty" yaml:"versionUrls,omitempty"`
 }
 
 type TemplateVersionCollection struct {

--- a/client/management/v3/zz_generated_template_version_spec.go
+++ b/client/management/v3/zz_generated_template_version_spec.go
@@ -13,6 +13,9 @@ const (
 	TemplateVersionSpecFieldRequiredNamespace   = "requiredNamespace"
 	TemplateVersionSpecFieldUpgradeVersionLinks = "upgradeVersionLinks"
 	TemplateVersionSpecFieldVersion             = "version"
+	TemplateVersionSpecFieldVersionDir          = "versionDir"
+	TemplateVersionSpecFieldVersionName         = "versionName"
+	TemplateVersionSpecFieldVersionURLs         = "versionUrls"
 )
 
 type TemplateVersionSpec struct {
@@ -27,4 +30,7 @@ type TemplateVersionSpec struct {
 	RequiredNamespace   string            `json:"requiredNamespace,omitempty" yaml:"requiredNamespace,omitempty"`
 	UpgradeVersionLinks map[string]string `json:"upgradeVersionLinks,omitempty" yaml:"upgradeVersionLinks,omitempty"`
 	Version             string            `json:"version,omitempty" yaml:"version,omitempty"`
+	VersionDir          string            `json:"versionDir,omitempty" yaml:"versionDir,omitempty"`
+	VersionName         string            `json:"versionName,omitempty" yaml:"versionName,omitempty"`
+	VersionURLs         []string          `json:"versionUrls,omitempty" yaml:"versionUrls,omitempty"`
 }


### PR DESCRIPTION
Add a new catalog condition for migrating catalog and templates to
remove files and questions, and new variables on template version for
easy retrieval from cache. Mark parameters that are injected with the
formatter as nocreate/noupdate. Adds comments for deprecated items.

For rancher/rancher/issues/14322