### PR TITLE
Add use tls config for syslog logging target

### DIFF
--- a/apis/management.cattle.io/v3/logging_types.go
+++ b/apis/management.cattle.io/v3/logging_types.go
@@ -141,6 +141,7 @@ type SyslogConfig struct {
 	Program     string `json:"program,omitempty"`
 	Protocol    string `json:"protocol,omitempty" norman:"default=udp,type=enum,options=udp|tcp"`
 	Token       string `json:"token,omitempty" norman:"type=password"`
+	EnableTLS   bool   `json:"enableTls,omitempty" norman:"default=false"`
 	Certificate string `json:"certificate,omitempty"`
 	ClientCert  string `json:"clientCert,omitempty"`
 	ClientKey   string `json:"clientKey,omitempty"`

--- a/client/management/v3/zz_generated_syslog_config.go
+++ b/client/management/v3/zz_generated_syslog_config.go
@@ -5,6 +5,7 @@ const (
 	SyslogConfigFieldCertificate = "certificate"
 	SyslogConfigFieldClientCert  = "clientCert"
 	SyslogConfigFieldClientKey   = "clientKey"
+	SyslogConfigFieldEnableTLS   = "enableTls"
 	SyslogConfigFieldEndpoint    = "endpoint"
 	SyslogConfigFieldProgram     = "program"
 	SyslogConfigFieldProtocol    = "protocol"
@@ -17,6 +18,7 @@ type SyslogConfig struct {
 	Certificate string `json:"certificate,omitempty" yaml:"certificate,omitempty"`
 	ClientCert  string `json:"clientCert,omitempty" yaml:"clientCert,omitempty"`
 	ClientKey   string `json:"clientKey,omitempty" yaml:"clientKey,omitempty"`
+	EnableTLS   bool   `json:"enableTls,omitempty" yaml:"enableTls,omitempty"`
 	Endpoint    string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
 	Program     string `json:"program,omitempty" yaml:"program,omitempty"`
 	Protocol    string `json:"protocol,omitempty" yaml:"protocol,omitempty"`


### PR DESCRIPTION
Problem:
can't identify whether the syslog target use tls or not

Solution:
add enable tls field

Issue:
https://github.com/rancher/rancher/issues/15380