### PR TITLE
GlobalDNS entry - Make FQDN non-updatable

### DIFF
--- a/apis/management.cattle.io/v3/globaldns_types.go
+++ b/apis/management.cattle.io/v3/globaldns_types.go
@@ -18,7 +18,7 @@ type GlobalDNS struct {
 }
 
 type GlobalDNSSpec struct {
-	FQDN                string   `json:"fqdn,omitempty" norman:"required"`
+	FQDN                string   `json:"fqdn,omitempty" norman:"required,noupdate"`
 	ProjectNames        []string `json:"projectNames" norman:"type=array[reference[project]]"`
 	MultiClusterAppName string   `json:"multiClusterAppName,omitempty" norman:"type=reference[multiClusterApp]"`
 	ProviderName        string   `json:"providerName,omitempty" norman:"type=reference[globalDnsProvider],required"`


### PR DESCRIPTION
Fix for https://github.com/rancher/rancher/issues/17832

Editing FQDN of the DNS entry is not allowed, editing it does not get propagate to the external-dns provider. User can always add a new entry and delete the existing