### PR TITLE
Update kontainer driver schemas

### DIFF
--- a/apis/management.cattle.io/v3/schema_types.go
+++ b/apis/management.cattle.io/v3/schema_types.go
@@ -18,18 +18,19 @@ type DynamicSchema struct {
 }
 
 type DynamicSchemaSpec struct {
-	SchemaName        string            `json:"schemaName,omitempty"`
-	Embed             bool              `json:"embed,omitempty"`
-	EmbedType         string            `json:"embedType,omitempty"`
-	PluralName        string            `json:"pluralName,omitempty"`
-	ResourceMethods   []string          `json:"resourceMethods,omitempty"`
-	ResourceFields    map[string]Field  `json:"resourceFields,omitempty"`
-	ResourceActions   map[string]Action `json:"resourceActions,omitempty"`
-	CollectionMethods []string          `json:"collectionMethods,omitempty"`
-	CollectionFields  map[string]Field  `json:"collectionFields,omitempty"`
-	CollectionActions map[string]Action `json:"collectionActions,omitempty"`
-	CollectionFilters map[string]Filter `json:"collectionFilters,omitempty"`
-	IncludeableLinks  []string          `json:"includeableLinks,omitempty"`
+	SchemaName           string            `json:"schemaName,omitempty"`
+	Embed                bool              `json:"embed,omitempty"`
+	EmbedType            string            `json:"embedType,omitempty"`
+	PluralName           string            `json:"pluralName,omitempty"`
+	ResourceMethods      []string          `json:"resourceMethods,omitempty"`
+	ResourceFields       map[string]Field  `json:"resourceFields,omitempty"`
+	ResourceActions      map[string]Action `json:"resourceActions,omitempty"`
+	CollectionMethods    []string          `json:"collectionMethods,omitempty"`
+	CollectionFields     map[string]Field  `json:"collectionFields,omitempty"`
+	CollectionActions    map[string]Action `json:"collectionActions,omitempty"`
+	CollectionFilters    map[string]Filter `json:"collectionFilters,omitempty"`
+	IncludeableLinks     []string          `json:"includeableLinks,omitempty"`
+	DynamicSchemaVersion string            `json:"dynamicSchemaVersion,omitempty"`
 }
 
 type DynamicSchemaStatus struct {

--- a/client/management/v3/zz_generated_dynamic_schema.go
+++ b/client/management/v3/zz_generated_dynamic_schema.go
@@ -13,6 +13,7 @@ const (
 	DynamicSchemaFieldCollectionMethods    = "collectionMethods"
 	DynamicSchemaFieldCreated              = "created"
 	DynamicSchemaFieldCreatorID            = "creatorId"
+	DynamicSchemaFieldDynamicSchemaVersion = "dynamicSchemaVersion"
 	DynamicSchemaFieldEmbed                = "embed"
 	DynamicSchemaFieldEmbedType            = "embedType"
 	DynamicSchemaFieldIncludeableLinks     = "includeableLinks"
@@ -41,6 +42,7 @@ type DynamicSchema struct {
 	CollectionMethods    []string             `json:"collectionMethods,omitempty" yaml:"collectionMethods,omitempty"`
 	Created              string               `json:"created,omitempty" yaml:"created,omitempty"`
 	CreatorID            string               `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
+	DynamicSchemaVersion string               `json:"dynamicSchemaVersion,omitempty" yaml:"dynamicSchemaVersion,omitempty"`
 	Embed                bool                 `json:"embed,omitempty" yaml:"embed,omitempty"`
 	EmbedType            string               `json:"embedType,omitempty" yaml:"embedType,omitempty"`
 	IncludeableLinks     []string             `json:"includeableLinks,omitempty" yaml:"includeableLinks,omitempty"`

--- a/client/management/v3/zz_generated_dynamic_schema_spec.go
+++ b/client/management/v3/zz_generated_dynamic_schema_spec.go
@@ -1,32 +1,34 @@
 package client
 
 const (
-	DynamicSchemaSpecType                   = "dynamicSchemaSpec"
-	DynamicSchemaSpecFieldCollectionActions = "collectionActions"
-	DynamicSchemaSpecFieldCollectionFields  = "collectionFields"
-	DynamicSchemaSpecFieldCollectionFilters = "collectionFilters"
-	DynamicSchemaSpecFieldCollectionMethods = "collectionMethods"
-	DynamicSchemaSpecFieldEmbed             = "embed"
-	DynamicSchemaSpecFieldEmbedType         = "embedType"
-	DynamicSchemaSpecFieldIncludeableLinks  = "includeableLinks"
-	DynamicSchemaSpecFieldPluralName        = "pluralName"
-	DynamicSchemaSpecFieldResourceActions   = "resourceActions"
-	DynamicSchemaSpecFieldResourceFields    = "resourceFields"
-	DynamicSchemaSpecFieldResourceMethods   = "resourceMethods"
-	DynamicSchemaSpecFieldSchemaName        = "schemaName"
+	DynamicSchemaSpecType                      = "dynamicSchemaSpec"
+	DynamicSchemaSpecFieldCollectionActions    = "collectionActions"
+	DynamicSchemaSpecFieldCollectionFields     = "collectionFields"
+	DynamicSchemaSpecFieldCollectionFilters    = "collectionFilters"
+	DynamicSchemaSpecFieldCollectionMethods    = "collectionMethods"
+	DynamicSchemaSpecFieldDynamicSchemaVersion = "dynamicSchemaVersion"
+	DynamicSchemaSpecFieldEmbed                = "embed"
+	DynamicSchemaSpecFieldEmbedType            = "embedType"
+	DynamicSchemaSpecFieldIncludeableLinks     = "includeableLinks"
+	DynamicSchemaSpecFieldPluralName           = "pluralName"
+	DynamicSchemaSpecFieldResourceActions      = "resourceActions"
+	DynamicSchemaSpecFieldResourceFields       = "resourceFields"
+	DynamicSchemaSpecFieldResourceMethods      = "resourceMethods"
+	DynamicSchemaSpecFieldSchemaName           = "schemaName"
 )
 
 type DynamicSchemaSpec struct {
-	CollectionActions map[string]Action `json:"collectionActions,omitempty" yaml:"collectionActions,omitempty"`
-	CollectionFields  map[string]Field  `json:"collectionFields,omitempty" yaml:"collectionFields,omitempty"`
-	CollectionFilters map[string]Filter `json:"collectionFilters,omitempty" yaml:"collectionFilters,omitempty"`
-	CollectionMethods []string          `json:"collectionMethods,omitempty" yaml:"collectionMethods,omitempty"`
-	Embed             bool              `json:"embed,omitempty" yaml:"embed,omitempty"`
-	EmbedType         string            `json:"embedType,omitempty" yaml:"embedType,omitempty"`
-	IncludeableLinks  []string          `json:"includeableLinks,omitempty" yaml:"includeableLinks,omitempty"`
-	PluralName        string            `json:"pluralName,omitempty" yaml:"pluralName,omitempty"`
-	ResourceActions   map[string]Action `json:"resourceActions,omitempty" yaml:"resourceActions,omitempty"`
-	ResourceFields    map[string]Field  `json:"resourceFields,omitempty" yaml:"resourceFields,omitempty"`
-	ResourceMethods   []string          `json:"resourceMethods,omitempty" yaml:"resourceMethods,omitempty"`
-	SchemaName        string            `json:"schemaName,omitempty" yaml:"schemaName,omitempty"`
+	CollectionActions    map[string]Action `json:"collectionActions,omitempty" yaml:"collectionActions,omitempty"`
+	CollectionFields     map[string]Field  `json:"collectionFields,omitempty" yaml:"collectionFields,omitempty"`
+	CollectionFilters    map[string]Filter `json:"collectionFilters,omitempty" yaml:"collectionFilters,omitempty"`
+	CollectionMethods    []string          `json:"collectionMethods,omitempty" yaml:"collectionMethods,omitempty"`
+	DynamicSchemaVersion string            `json:"dynamicSchemaVersion,omitempty" yaml:"dynamicSchemaVersion,omitempty"`
+	Embed                bool              `json:"embed,omitempty" yaml:"embed,omitempty"`
+	EmbedType            string            `json:"embedType,omitempty" yaml:"embedType,omitempty"`
+	IncludeableLinks     []string          `json:"includeableLinks,omitempty" yaml:"includeableLinks,omitempty"`
+	PluralName           string            `json:"pluralName,omitempty" yaml:"pluralName,omitempty"`
+	ResourceActions      map[string]Action `json:"resourceActions,omitempty" yaml:"resourceActions,omitempty"`
+	ResourceFields       map[string]Field  `json:"resourceFields,omitempty" yaml:"resourceFields,omitempty"`
+	ResourceMethods      []string          `json:"resourceMethods,omitempty" yaml:"resourceMethods,omitempty"`
+	SchemaName           string            `json:"schemaName,omitempty" yaml:"schemaName,omitempty"`
 }


### PR DESCRIPTION
This change adds a schema version field so that we can track what resource
version of a dynamic schema a schema was created from, to minimize the amount
of updates we need to do.

Issue:
https://github.com/rancher/rancher/issues/17712