### PR TITLE
 Fix norman type in UpdateMultiClusterAppTargetsInput answers

### DIFF
--- a/apis/management.cattle.io/v3/multi_cluster_app.go
+++ b/apis/management.cattle.io/v3/multi_cluster_app.go
@@ -85,5 +85,5 @@ type MultiClusterAppRollbackInput struct {
 
 type UpdateMultiClusterAppTargetsInput struct {
 	Projects []string `json:"projects" norman:"type=array[reference[project]],required"`
-	Answers  []Answer `json:"answers" norman:"type=array[reference[answer]]"`
+	Answers  []Answer `json:"answers"`
 }

--- a/client/management/v3/zz_generated_update_multi_cluster_app_targets_input.go
+++ b/client/management/v3/zz_generated_update_multi_cluster_app_targets_input.go
@@ -7,6 +7,6 @@ const (
 )
 
 type UpdateMultiClusterAppTargetsInput struct {
-	Answers  []string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	Answers  []Answer `json:"answers,omitempty" yaml:"answers,omitempty"`
 	Projects []string `json:"projects,omitempty" yaml:"projects,omitempty"`
 }


### PR DESCRIPTION
Related issue: https://github.com/rancher/rancher/issues/17981

Problem:
The answers field is marked as reference. As a result, The generated field gets a wrong type: https://github.com/rancher/types/blob/304eef54e2a4b5373726ca6970a944f40770856b/client/management/v3/zz_generated_update_multi_cluster_app_targets_input.go#L10

Solution:
Remove norman type of answers field