### PR TITLE
Default the GlobalDNS entry TTL to 300s

### DIFF
--- a/apis/management.cattle.io/v3/globaldns_types.go
+++ b/apis/management.cattle.io/v3/globaldns_types.go
@@ -19,7 +19,7 @@ type GlobalDNS struct {
 
 type GlobalDNSSpec struct {
 	FQDN                string   `json:"fqdn,omitempty" norman:"required"`
-	TTL                 int64    `json:"ttl,omitempty"`
+	TTL                 int64    `json:"ttl,omitempty" norman:"default=300"`
 	ProjectNames        []string `json:"projectNames" norman:"type=array[reference[project]],noupdate"`
 	MultiClusterAppName string   `json:"multiClusterAppName,omitempty" norman:"type=reference[multiClusterApp]"`
 	ProviderName        string   `json:"providerName,omitempty" norman:"type=reference[globalDnsProvider],required"`


### PR DESCRIPTION
Fix for: https://github.com/rancher/rancher/issues/18198

Most of the GlobalDNS providers default the TTL value to 300s. So changing the default to 300s.