### PR TITLE
add client key and certificate for logging fluentd

### DIFF
--- a/apis/management.cattle.io/v3/logging_types.go
+++ b/apis/management.cattle.io/v3/logging_types.go
@@ -151,6 +151,10 @@ type SyslogConfig struct {
 type FluentForwarderConfig struct {
 	EnableTLS     bool           `json:"enableTls,omitempty" norman:"default=false"`
 	Certificate   string         `json:"certificate,omitempty"`
+	ClientCert    string         `json:"clientCert,omitempty"`
+	ClientKey     string         `json:"clientKey,omitempty"`
+	ClientKeyPass string         `json:"clientKeyPass,omitempty"`
+	SSLVerify     bool           `json:"sslVerify,omitempty"`
 	Compress      bool           `json:"compress,omitempty" norman:"default=true"`
 	FluentServers []FluentServer `json:"fluentServers,omitempty" norman:"required"`
 }

--- a/client/management/v3/zz_generated_fluent_forwarder_config.go
+++ b/client/management/v3/zz_generated_fluent_forwarder_config.go
@@ -3,14 +3,22 @@ package client
 const (
 	FluentForwarderConfigType               = "fluentForwarderConfig"
 	FluentForwarderConfigFieldCertificate   = "certificate"
+	FluentForwarderConfigFieldClientCert    = "clientCert"
+	FluentForwarderConfigFieldClientKey     = "clientKey"
+	FluentForwarderConfigFieldClientKeyPass = "clientKeyPass"
 	FluentForwarderConfigFieldCompress      = "compress"
 	FluentForwarderConfigFieldEnableTLS     = "enableTls"
 	FluentForwarderConfigFieldFluentServers = "fluentServers"
+	FluentForwarderConfigFieldSSLVerify     = "sslVerify"
 )
 
 type FluentForwarderConfig struct {
 	Certificate   string         `json:"certificate,omitempty" yaml:"certificate,omitempty"`
+	ClientCert    string         `json:"clientCert,omitempty" yaml:"clientCert,omitempty"`
+	ClientKey     string         `json:"clientKey,omitempty" yaml:"clientKey,omitempty"`
+	ClientKeyPass string         `json:"clientKeyPass,omitempty" yaml:"clientKeyPass,omitempty"`
 	Compress      bool           `json:"compress,omitempty" yaml:"compress,omitempty"`
 	EnableTLS     bool           `json:"enableTls,omitempty" yaml:"enableTls,omitempty"`
 	FluentServers []FluentServer `json:"fluentServers,omitempty" yaml:"fluentServers,omitempty"`
+	SSLVerify     bool           `json:"sslVerify,omitempty" yaml:"sslVerify,omitempty"`
 }


### PR DESCRIPTION
Problem:
advance mode have support client key and certificate for fluentd logging
target but normal mode not yet

Solution:
add client key and certificate for fluentd

Issue:
https://github.com/rancher/rancher/issues/18438