### PR TITLE
Adjust kubelet bootstrap option for Windows

### DIFF
--- a/apis/management.cattle.io/v3/k8s_windows_default.go
+++ b/apis/management.cattle.io/v3/k8s_windows_default.go
@@ -43,17 +43,25 @@ var (
 		"v1.12": {
 			Kubelet: map[string]string{
 				"tls-cipher-suites":        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-				"feature-gates":            "MountPropagation=false,HyperVContainer=true",
+				"feature-gates":            "HyperVContainer=true",
 				"cgroups-per-qos":          "false",
 				"enforce-node-allocatable": "",
 				"resolv-conf":              "",
-				"cadvisor-port":            "",
 			},
 		},
 		"v1.13": {
 			Kubelet: map[string]string{
 				"tls-cipher-suites":        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-				"feature-gates":            "MountPropagation=false,HyperVContainer=true",
+				"feature-gates":            "HyperVContainer=true",
+				"cgroups-per-qos":          "false",
+				"enforce-node-allocatable": "",
+				"resolv-conf":              "",
+			},
+		},
+		"v1.14": {
+			Kubelet: map[string]string{
+				"tls-cipher-suites":        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+				"feature-gates":            "HyperVContainer=true",
 				"cgroups-per-qos":          "false",
 				"enforce-node-allocatable": "",
 				"resolv-conf":              "",
@@ -62,7 +70,7 @@ var (
 	}
 
 	// AllK8sWindowsVersions - images map for 2.0
-	allK8sWindowsVersions = map[string]WindowsSystemImages{
+	AllK8sWindowsVersions = map[string]WindowsSystemImages{
 		"v1.8.10-rancher1-1": {
 			NginxProxy:         m("rancher/nginx-proxy:v0.0.1-nanoserver-1803"),
 			KubernetesBinaries: m("rancher/hyperkube:v1.8.10-nanoserver-1803"),
@@ -325,23 +333,15 @@ var (
 			KubeletPause:       m("rancher/kubelet-pause:v0.0.1-nanoserver-1803"),
 		},
 		"v1.14.1-rancher1-2": {
-			NginxProxy:         m("rancher/nginx-proxy:v0.0.1-nanoserver-1803"),
-			KubernetesBinaries: m("rancher/hyperkube:v1.14.1-nanoserver-1803"),
-			FlannelCNIBinaries: m("rancher/flannel-cni:v0.0.1-nanoserver-1803"),
-			CalicoCNIBinaries:  m("rancher/calico-cni:v0.0.1-nanoserver-1803"),
-			CanalCNIBinaries:   m("rancher/canal-cni:v0.0.1-nanoserver-1803"),
-			KubeletPause:       m("rancher/kubelet-pause:v0.0.1-nanoserver-1803"),
+			// NginxProxy image is replaced by host running nginx, fixed rancher#16074
+			KubernetesBinaries: m("rancher/hyperkube:v1.14.1-rancher2"),
+			FlannelCNIBinaries: m("rancher/flannel-cni:v0.3.0-rancher3"),
+			KubeletPause:       m("rancher/kubelet-pause:v0.1.2"),
 		},
 	}
 )
 
 func initWindows() {
-	badVersions := map[string]bool{
-		"v1.8.11-rancher2-1": true,
-		"v1.8.11-rancher1":   true,
-		"v1.8.10-rancher1-1": true,
-	}
-
 	if K8sVersionWindowsSystemImages != nil {
 		panic("Do not initialize or add values to K8sVersionWindowsSystemImages")
 	}
@@ -349,11 +349,11 @@ func initWindows() {
 	K8sVersionWindowsSystemImages = map[string]WindowsSystemImages{}
 
 	for version := range K8sVersionToRKESystemImages {
-		if badVersions[version] {
+		if K8sBadVersions[version] {
 			continue
 		}
 
-		images, ok := allK8sWindowsVersions[version]
+		images, ok := AllK8sWindowsVersions[version]
 		if !ok {
 			panic("K8s version " + " is not found in AllK8sWindowsVersions map")
 		}


### PR DESCRIPTION
- v1.12
   + Drop cadvisor-port
   + Drop MountPropagation from feature-gates
- v1.13
   + Drop MountPropagation from feature-gates
- v1.14
   + Support
   + Remove `nanoserver-1803` suffix

**Issues:**
rancher/rancher#17341