### PR TITLE
Update notifier to not required

### DIFF
--- a/apis/management.cattle.io/v3/alerting_types.go
+++ b/apis/management.cattle.io/v3/alerting_types.go
@@ -129,13 +129,13 @@ type ProjectAlertGroup struct {
 
 type ClusterGroupSpec struct {
 	ClusterName string      `json:"clusterName" norman:"type=reference[cluster]"`
-	Recipients  []Recipient `json:"recipients,omitempty" norman:"required"`
+	Recipients  []Recipient `json:"recipients,omitempty"`
 	CommonGroupField
 }
 
 type ProjectGroupSpec struct {
 	ProjectName string      `json:"projectName" norman:"type=reference[project]"`
-	Recipients  []Recipient `json:"recipients,omitempty" norman:"required"`
+	Recipients  []Recipient `json:"recipients,omitempty"`
 	CommonGroupField
 }
 


### PR DESCRIPTION
Problem:
User prefer allow empty notifier

Solution:
Allow empty notifer in cluster/project group

Issue:
https://github.com/rancher/rancher/issues/18616