### PR TITLE
GlobalDNS FQDN should be of type hostname

### DIFF
--- a/apis/management.cattle.io/v3/globaldns_types.go
+++ b/apis/management.cattle.io/v3/globaldns_types.go
@@ -18,7 +18,7 @@ type GlobalDNS struct {
 }
 
 type GlobalDNSSpec struct {
-	FQDN                string   `json:"fqdn,omitempty" norman:"required"`
+	FQDN                string   `json:"fqdn,omitempty" norman:"type=hostname,required"`
 	TTL                 int64    `json:"ttl,omitempty" norman:"default=300"`
 	ProjectNames        []string `json:"projectNames" norman:"type=array[reference[project]],noupdate"`
 	MultiClusterAppName string   `json:"multiClusterAppName,omitempty" norman:"type=reference[multiClusterApp]"`


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/19738

Now the GlobalDNS FQDN is of type "hostname" which is a series of dnsLabels, that can only have alphanumeric characters and hyphen(-), separated by dot(.) 