### PR TITLE
Added taints to node config for use in RKE

### DIFF
--- a/apis/management.cattle.io/v3/rke_types.go
+++ b/apis/management.cattle.io/v3/rke_types.go
@@ -167,6 +167,8 @@ type RKEConfigNode struct {
 	SSHCertPath string `yaml:"ssh_cert_path" json:"sshCertPath,omitempty"`
 	// Node Labels
 	Labels map[string]string `yaml:"labels" json:"labels,omitempty"`
+	// Node Taints
+	Taints []string `yaml:"taints" json:"taints,omitempty"`
 }
 
 type RKEConfigServices struct {
@@ -330,6 +332,8 @@ type RKEConfigNodePlan struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 	// Node Labels
 	Labels map[string]string `json:"labels,omitempty"`
+	// Node Taints
+	Taints []string `json:"taints,omitempty"`
 }
 
 type Process struct {

--- a/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -7050,6 +7050,11 @@ func (in *RKEConfigNode) DeepCopyInto(out *RKEConfigNode) {
 			(*out)[key] = val
 		}
 	}
+	if in.Taints != nil {
+		in, out := &in.Taints, &out.Taints
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -7096,6 +7101,11 @@ func (in *RKEConfigNodePlan) DeepCopyInto(out *RKEConfigNodePlan) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.Taints != nil {
+		in, out := &in.Taints, &out.Taints
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/client/management/v3/zz_generated_rke_config_node.go
+++ b/client/management/v3/zz_generated_rke_config_node.go
@@ -15,6 +15,7 @@ const (
 	RKEConfigNodeFieldSSHCertPath      = "sshCertPath"
 	RKEConfigNodeFieldSSHKey           = "sshKey"
 	RKEConfigNodeFieldSSHKeyPath       = "sshKeyPath"
+	RKEConfigNodeFieldTaints           = "taints"
 	RKEConfigNodeFieldUser             = "user"
 )
 
@@ -32,5 +33,6 @@ type RKEConfigNode struct {
 	SSHCertPath      string            `json:"sshCertPath,omitempty" yaml:"sshCertPath,omitempty"`
 	SSHKey           string            `json:"sshKey,omitempty" yaml:"sshKey,omitempty"`
 	SSHKeyPath       string            `json:"sshKeyPath,omitempty" yaml:"sshKeyPath,omitempty"`
+	Taints           []string          `json:"taints,omitempty" yaml:"taints,omitempty"`
 	User             string            `json:"user,omitempty" yaml:"user,omitempty"`
 }


### PR DESCRIPTION
I wanted to add to RKE the ability to specify taints alongside labels in the cluster.yml file.