### PR TITLE
minor refactor

### DIFF
--- a/apis/management.cattle.io/v3/cluster_types.go
+++ b/apis/management.cattle.io/v3/cluster_types.go
@@ -20,6 +20,17 @@ func init() {
 type ClusterConditionType string
 
 const (
+	ClusterActionGenerateKubeconfig    = "generateKubeconfig"
+	ClusterActionImportYaml            = "importYaml"
+	ClusterActionExportYaml            = "exportYaml"
+	ClusterActionViewMonitoring        = "viewMonitoring"
+	ClusterActionEditMonitoring        = "editMonitoring"
+	ClusterActionEnableMonitoring      = "enableMonitoring"
+	ClusterActionDisableMonitoring     = "disableMonitoring"
+	ClusterActionBackupEtcd            = "backupEtcd"
+	ClusterActionRestoreFromEtcdBackup = "restoreFromEtcdBackup"
+	ClusterActionRotateCertificates    = "rotateCertificates"
+
 	// ClusterConditionReady Cluster ready to serve API (healthy when true, unhealthy when false)
 	ClusterConditionReady          condition.Cond = "Ready"
 	ClusterConditionPending        condition.Cond = "Pending"

--- a/apis/management.cattle.io/v3/schema/schema.go
+++ b/apis/management.cattle.io/v3/schema/schema.go
@@ -198,31 +198,31 @@ func clusterTypes(schemas *types.Schemas) *types.Schemas {
 				field.Required = false
 				return field
 			})
-			schema.ResourceActions["generateKubeconfig"] = types.Action{
+			schema.ResourceActions[v3.ClusterActionGenerateKubeconfig] = types.Action{
 				Output: "generateKubeConfigOutput",
 			}
-			schema.ResourceActions["importYaml"] = types.Action{
+			schema.ResourceActions[v3.ClusterActionImportYaml] = types.Action{
 				Input:  "importClusterYamlInput",
 				Output: "importYamlOutput",
 			}
-			schema.ResourceActions["exportYaml"] = types.Action{
+			schema.ResourceActions[v3.ClusterActionExportYaml] = types.Action{
 				Output: "exportOutput",
 			}
-			schema.ResourceActions["enableMonitoring"] = types.Action{
+			schema.ResourceActions[v3.ClusterActionEnableMonitoring] = types.Action{
 				Input: "monitoringInput",
 			}
-			schema.ResourceActions["disableMonitoring"] = types.Action{}
-			schema.ResourceActions["viewMonitoring"] = types.Action{
+			schema.ResourceActions[v3.ClusterActionDisableMonitoring] = types.Action{}
+			schema.ResourceActions[v3.ClusterActionViewMonitoring] = types.Action{
 				Output: "monitoringOutput",
 			}
-			schema.ResourceActions["editMonitoring"] = types.Action{
+			schema.ResourceActions[v3.ClusterActionEditMonitoring] = types.Action{
 				Input: "monitoringInput",
 			}
-			schema.ResourceActions["backupEtcd"] = types.Action{}
-			schema.ResourceActions["restoreFromEtcdBackup"] = types.Action{
+			schema.ResourceActions[v3.ClusterActionBackupEtcd] = types.Action{}
+			schema.ResourceActions[v3.ClusterActionRestoreFromEtcdBackup] = types.Action{
 				Input: "restoreFromEtcdBackupInput",
 			}
-			schema.ResourceActions["rotateCertificates"] = types.Action{
+			schema.ResourceActions[v3.ClusterActionRotateCertificates] = types.Action{
 				Input:  "rotateCertificateInput",
 				Output: "rotateCertificateOutput",
 			}


### PR DESCRIPTION
Currently, these actions are being used as strings in "rancher/rancher". This refactor will enable to use these constants instead.