### PR TITLE
Update goimports

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -6,7 +6,7 @@ RUN go get -d golang.org/x/lint/golint && \
     go install golang.org/x/lint/golint && \
     rm -rf /go/src /go/pkg
 RUN go get -d golang.org/x/tools/cmd/goimports && \
-    git -C /go/src/golang.org/x/tools/cmd/goimports checkout -b current 0b24b358f4c7eaa92895f67a3f6cea2a0cf525d5 && \
+    git -C /go/src/golang.org/x/tools/cmd/goimports checkout -b current 26e35f15edef9a960ed13c88b445c5674371da18 && \
     go install golang.org/x/tools/cmd/goimports && \
     rm -rf /go/src /go/pkg
 

--- a/apis/batch/v1/zz_generated_job_controller.go
+++ b/apis/batch/v1/zz_generated_job_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/batch/v1"
+	v1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/batch/v1/zz_generated_job_lifecycle_adapter.go
+++ b/apis/batch/v1/zz_generated_job_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/batch/v1"
+	v1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/cluster.cattle.io/v3/schema/schema.go
+++ b/apis/cluster.cattle.io/v3/schema/schema.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/rancher/norman/types"
 	m "github.com/rancher/norman/types/mapper"
-	"github.com/rancher/types/apis/cluster.cattle.io/v3"
+	v3 "github.com/rancher/types/apis/cluster.cattle.io/v3"
 	"github.com/rancher/types/factory"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 )
 

--- a/apis/core/v1/zz_generated_component_status_controller.go
+++ b/apis/core/v1/zz_generated_component_status_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/core/v1/zz_generated_component_status_lifecycle_adapter.go
+++ b/apis/core/v1/zz_generated_component_status_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/core/v1/zz_generated_config_map_controller.go
+++ b/apis/core/v1/zz_generated_config_map_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/core/v1/zz_generated_config_map_lifecycle_adapter.go
+++ b/apis/core/v1/zz_generated_config_map_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/core/v1/zz_generated_endpoints_controller.go
+++ b/apis/core/v1/zz_generated_endpoints_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/core/v1/zz_generated_endpoints_lifecycle_adapter.go
+++ b/apis/core/v1/zz_generated_endpoints_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/core/v1/zz_generated_event_controller.go
+++ b/apis/core/v1/zz_generated_event_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/core/v1/zz_generated_event_lifecycle_adapter.go
+++ b/apis/core/v1/zz_generated_event_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/core/v1/zz_generated_limit_range_controller.go
+++ b/apis/core/v1/zz_generated_limit_range_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/core/v1/zz_generated_limit_range_lifecycle_adapter.go
+++ b/apis/core/v1/zz_generated_limit_range_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/core/v1/zz_generated_namespace_controller.go
+++ b/apis/core/v1/zz_generated_namespace_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/core/v1/zz_generated_namespace_lifecycle_adapter.go
+++ b/apis/core/v1/zz_generated_namespace_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/core/v1/zz_generated_node_controller.go
+++ b/apis/core/v1/zz_generated_node_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/core/v1/zz_generated_node_lifecycle_adapter.go
+++ b/apis/core/v1/zz_generated_node_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/core/v1/zz_generated_persistent_volume_claim_controller.go
+++ b/apis/core/v1/zz_generated_persistent_volume_claim_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/core/v1/zz_generated_persistent_volume_claim_lifecycle_adapter.go
+++ b/apis/core/v1/zz_generated_persistent_volume_claim_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/core/v1/zz_generated_pod_controller.go
+++ b/apis/core/v1/zz_generated_pod_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/core/v1/zz_generated_pod_lifecycle_adapter.go
+++ b/apis/core/v1/zz_generated_pod_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/core/v1/zz_generated_replication_controller_controller.go
+++ b/apis/core/v1/zz_generated_replication_controller_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/core/v1/zz_generated_replication_controller_lifecycle_adapter.go
+++ b/apis/core/v1/zz_generated_replication_controller_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/core/v1/zz_generated_resource_quota_controller.go
+++ b/apis/core/v1/zz_generated_resource_quota_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/core/v1/zz_generated_resource_quota_lifecycle_adapter.go
+++ b/apis/core/v1/zz_generated_resource_quota_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/core/v1/zz_generated_secret_controller.go
+++ b/apis/core/v1/zz_generated_secret_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/core/v1/zz_generated_secret_lifecycle_adapter.go
+++ b/apis/core/v1/zz_generated_secret_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/core/v1/zz_generated_service_account_controller.go
+++ b/apis/core/v1/zz_generated_service_account_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/core/v1/zz_generated_service_account_lifecycle_adapter.go
+++ b/apis/core/v1/zz_generated_service_account_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/core/v1/zz_generated_service_controller.go
+++ b/apis/core/v1/zz_generated_service_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/core/v1/zz_generated_service_lifecycle_adapter.go
+++ b/apis/core/v1/zz_generated_service_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/management.cattle.io/v3/authz_types.go
+++ b/apis/management.cattle.io/v3/authz_types.go
@@ -3,7 +3,7 @@ package v3
 import (
 	"github.com/rancher/norman/condition"
 	"github.com/rancher/norman/types"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/api/extensions/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/apis/management.cattle.io/v3/backup_types.go
+++ b/apis/management.cattle.io/v3/backup_types.go
@@ -3,7 +3,7 @@ package v3
 import (
 	"github.com/rancher/norman/condition"
 	"github.com/rancher/norman/types"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/management.cattle.io/v3/catalog_types.go
+++ b/apis/management.cattle.io/v3/catalog_types.go
@@ -3,7 +3,7 @@ package v3
 import (
 	"github.com/rancher/norman/condition"
 	"github.com/rancher/norman/types"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/management.cattle.io/v3/cluster_types.go
+++ b/apis/management.cattle.io/v3/cluster_types.go
@@ -7,7 +7,7 @@ import (
 	"github.com/rancher/norman/condition"
 	"github.com/rancher/norman/types"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 )

--- a/apis/management.cattle.io/v3/compose_types.go
+++ b/apis/management.cattle.io/v3/compose_types.go
@@ -2,7 +2,7 @@ package v3
 
 import (
 	"github.com/rancher/norman/condition"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/management.cattle.io/v3/logging_types.go
+++ b/apis/management.cattle.io/v3/logging_types.go
@@ -3,7 +3,7 @@ package v3
 import (
 	"github.com/rancher/norman/condition"
 	"github.com/rancher/norman/types"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/management.cattle.io/v3/monitoring_types.go
+++ b/apis/management.cattle.io/v3/monitoring_types.go
@@ -3,7 +3,7 @@ package v3
 import (
 	"github.com/rancher/norman/condition"
 	"github.com/rancher/norman/types"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/management.cattle.io/v3/multi_cluster_app.go
+++ b/apis/management.cattle.io/v3/multi_cluster_app.go
@@ -3,7 +3,7 @@ package v3
 import (
 	"github.com/rancher/norman/condition"
 	"github.com/rancher/norman/types"
-	"github.com/rancher/types/apis/project.cattle.io/v3"
+	v3 "github.com/rancher/types/apis/project.cattle.io/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/management.cattle.io/v3/schema/schema.go
+++ b/apis/management.cattle.io/v3/schema/schema.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/rancher/norman/types"
 	m "github.com/rancher/norman/types/mapper"
-	"github.com/rancher/types/apis/management.cattle.io/v3"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/factory"
 	"github.com/rancher/types/mapper"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 var (

--- a/apis/management.cattle.io/v3public/schema/public_schema.go
+++ b/apis/management.cattle.io/v3public/schema/public_schema.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/rancher/norman/types"
-	"github.com/rancher/types/apis/management.cattle.io/v3"
+	v3 "github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/apis/management.cattle.io/v3public"
 	"github.com/rancher/types/factory"
 )

--- a/apis/monitoring.coreos.com/v1/zz_generated_alertmanager_controller.go
+++ b/apis/monitoring.coreos.com/v1/zz_generated_alertmanager_controller.go
@@ -3,7 +3,7 @@ package v1
 import (
 	"context"
 
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
+	v1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"

--- a/apis/monitoring.coreos.com/v1/zz_generated_alertmanager_lifecycle_adapter.go
+++ b/apis/monitoring.coreos.com/v1/zz_generated_alertmanager_lifecycle_adapter.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
+	v1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/rancher/norman/lifecycle"
 	"k8s.io/apimachinery/pkg/runtime"
 )

--- a/apis/monitoring.coreos.com/v1/zz_generated_prometheus_controller.go
+++ b/apis/monitoring.coreos.com/v1/zz_generated_prometheus_controller.go
@@ -3,7 +3,7 @@ package v1
 import (
 	"context"
 
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
+	v1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"

--- a/apis/monitoring.coreos.com/v1/zz_generated_prometheus_lifecycle_adapter.go
+++ b/apis/monitoring.coreos.com/v1/zz_generated_prometheus_lifecycle_adapter.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
+	v1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/rancher/norman/lifecycle"
 	"k8s.io/apimachinery/pkg/runtime"
 )

--- a/apis/monitoring.coreos.com/v1/zz_generated_prometheus_rule_controller.go
+++ b/apis/monitoring.coreos.com/v1/zz_generated_prometheus_rule_controller.go
@@ -3,7 +3,7 @@ package v1
 import (
 	"context"
 
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
+	v1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"

--- a/apis/monitoring.coreos.com/v1/zz_generated_prometheus_rule_lifecycle_adapter.go
+++ b/apis/monitoring.coreos.com/v1/zz_generated_prometheus_rule_lifecycle_adapter.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
+	v1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/rancher/norman/lifecycle"
 	"k8s.io/apimachinery/pkg/runtime"
 )

--- a/apis/monitoring.coreos.com/v1/zz_generated_service_monitor_controller.go
+++ b/apis/monitoring.coreos.com/v1/zz_generated_service_monitor_controller.go
@@ -3,7 +3,7 @@ package v1
 import (
 	"context"
 
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
+	v1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"

--- a/apis/monitoring.coreos.com/v1/zz_generated_service_monitor_lifecycle_adapter.go
+++ b/apis/monitoring.coreos.com/v1/zz_generated_service_monitor_lifecycle_adapter.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	"github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
+	v1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/rancher/norman/lifecycle"
 	"k8s.io/apimachinery/pkg/runtime"
 )

--- a/apis/networking.k8s.io/v1/zz_generated_network_policy_controller.go
+++ b/apis/networking.k8s.io/v1/zz_generated_network_policy_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/networking/v1"
+	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/networking.k8s.io/v1/zz_generated_network_policy_lifecycle_adapter.go
+++ b/apis/networking.k8s.io/v1/zz_generated_network_policy_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/networking/v1"
+	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/project.cattle.io/v3/app_types.go
+++ b/apis/project.cattle.io/v3/app_types.go
@@ -3,7 +3,7 @@ package v3
 import (
 	"github.com/rancher/norman/condition"
 	"github.com/rancher/norman/types"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/project.cattle.io/v3/pipeline_types.go
+++ b/apis/project.cattle.io/v3/pipeline_types.go
@@ -5,7 +5,7 @@ import (
 	"github.com/rancher/norman/condition"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/project.cattle.io/v3/schema/schema.go
+++ b/apis/project.cattle.io/v3/schema/schema.go
@@ -6,14 +6,14 @@ import (
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
 	"github.com/rancher/norman/types"
 	m "github.com/rancher/norman/types/mapper"
-	"github.com/rancher/types/apis/project.cattle.io/v3"
+	v3 "github.com/rancher/types/apis/project.cattle.io/v3"
 	"github.com/rancher/types/factory"
 	"github.com/rancher/types/mapper"
 	"k8s.io/api/apps/v1beta2"
 	autoscaling "k8s.io/api/autoscaling/v2beta2"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 )
 

--- a/apis/project.cattle.io/v3/schema/schema_secrets.go
+++ b/apis/project.cattle.io/v3/schema/schema_secrets.go
@@ -4,8 +4,8 @@ import (
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
 	m "github.com/rancher/norman/types/mapper"
-	"github.com/rancher/types/apis/project.cattle.io/v3"
-	"k8s.io/api/core/v1"
+	v3 "github.com/rancher/types/apis/project.cattle.io/v3"
+	v1 "k8s.io/api/core/v1"
 )
 
 func secretTypes(schemas *types.Schemas) *types.Schemas {

--- a/apis/project.cattle.io/v3/schema/types.go
+++ b/apis/project.cattle.io/v3/schema/types.go
@@ -3,7 +3,7 @@ package schema
 import (
 	"github.com/rancher/norman/types"
 	m "github.com/rancher/norman/types/mapper"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_binding_controller.go
+++ b/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_binding_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_binding_lifecycle_adapter.go
+++ b/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_binding_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_controller.go
+++ b/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_lifecycle_adapter.go
+++ b/apis/rbac.authorization.k8s.io/v1/zz_generated_cluster_role_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/rbac.authorization.k8s.io/v1/zz_generated_role_binding_controller.go
+++ b/apis/rbac.authorization.k8s.io/v1/zz_generated_role_binding_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/rbac.authorization.k8s.io/v1/zz_generated_role_binding_lifecycle_adapter.go
+++ b/apis/rbac.authorization.k8s.io/v1/zz_generated_role_binding_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/rbac.authorization.k8s.io/v1/zz_generated_role_controller.go
+++ b/apis/rbac.authorization.k8s.io/v1/zz_generated_role_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher/norman/controller"
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/resource"
-	"k8s.io/api/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/apis/rbac.authorization.k8s.io/v1/zz_generated_role_lifecycle_adapter.go
+++ b/apis/rbac.authorization.k8s.io/v1/zz_generated_role_lifecycle_adapter.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"github.com/rancher/norman/lifecycle"
-	"k8s.io/api/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 


### PR DESCRIPTION
Problem:
goimports is outdated, causing builds to fail if machine that originally ran goimports is up to date. This is caused by the alias changes to goimports

Solution:
update goimports