### PR TITLE
ClusterTemplate use name mapper for displayName

### DIFF
--- a/apis/management.cattle.io/v3/schema/schema.go
+++ b/apis/management.cattle.io/v3/schema/schema.go
@@ -827,7 +827,7 @@ func clusterTemplateTypes(schemas *types.Schemas) *types.Schemas {
 	return schemas.
 		TypeName("clusterTemplate", v3.ClusterTemplate{}).
 		TypeName("clusterTemplateRevision", v3.ClusterTemplateRevision{}).
-		AddMapperForType(&Version, v3.ClusterTemplate{}, m.Drop{Field: "namespaceId"}).
+		AddMapperForType(&Version, v3.ClusterTemplate{}, m.Drop{Field: "namespaceId"}, m.DisplayName{}).
 		AddMapperForType(&Version, v3.ClusterTemplateRevision{}, m.Drop{Field: "namespaceId"}).
 		MustImport(&Version, v3.ClusterTemplate{}).
 		MustImport(&Version, v3.ClusterTemplateRevision{})

--- a/client/management/v3/zz_generated_cluster_template.go
+++ b/client/management/v3/zz_generated_cluster_template.go
@@ -11,7 +11,6 @@ const (
 	ClusterTemplateFieldCreatorID         = "creatorId"
 	ClusterTemplateFieldDefaultRevisionID = "defaultRevisionId"
 	ClusterTemplateFieldDescription       = "description"
-	ClusterTemplateFieldDisplayName       = "displayName"
 	ClusterTemplateFieldEnabled           = "enabled"
 	ClusterTemplateFieldLabels            = "labels"
 	ClusterTemplateFieldMembers           = "members"
@@ -28,7 +27,6 @@ type ClusterTemplate struct {
 	CreatorID         string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	DefaultRevisionID string            `json:"defaultRevisionId,omitempty" yaml:"defaultRevisionId,omitempty"`
 	Description       string            `json:"description,omitempty" yaml:"description,omitempty"`
-	DisplayName       string            `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	Enabled           *bool             `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 	Labels            map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Members           []Member          `json:"members,omitempty" yaml:"members,omitempty"`


### PR DESCRIPTION
We should be mapping displayName -> name on the schema, similar to the Cluster object. UI does not expect the schema to expose displayName field.

