### PR TITLE
Bring back host field in HttpGet probe

### DIFF
--- a/apis/project.cattle.io/v3/schema/schema.go
+++ b/apis/project.cattle.io/v3/schema/schema.go
@@ -486,9 +486,6 @@ func podTypes(schemas *types.Schemas) *types.Schemas {
 		AddMapperForType(&Version, v1.PodTemplateSpec{},
 			&m.Embed{Field: "spec"},
 		).
-		AddMapperForType(&Version, v1.HTTPGetAction{},
-			&m.Drop{Field: "host"},
-		).
 		AddMapperForType(&Version, v1.Capabilities{},
 			m.Move{From: "add", To: "capAdd"},
 			m.Move{From: "drop", To: "capDrop"},

--- a/client/project/v3/zz_generated_http_get_action.go
+++ b/client/project/v3/zz_generated_http_get_action.go
@@ -5,6 +5,7 @@ import "k8s.io/apimachinery/pkg/util/intstr"
 const (
 	HTTPGetActionType             = "httpGetAction"
 	HTTPGetActionFieldHTTPHeaders = "httpHeaders"
+	HTTPGetActionFieldHost        = "host"
 	HTTPGetActionFieldPath        = "path"
 	HTTPGetActionFieldPort        = "port"
 	HTTPGetActionFieldScheme      = "scheme"
@@ -12,6 +13,7 @@ const (
 
 type HTTPGetAction struct {
 	HTTPHeaders []HTTPHeader       `json:"httpHeaders,omitempty" yaml:"httpHeaders,omitempty"`
+	Host        string             `json:"host,omitempty" yaml:"host,omitempty"`
 	Path        string             `json:"path,omitempty" yaml:"path,omitempty"`
 	Port        intstr.IntOrString `json:"port,omitempty" yaml:"port,omitempty"`
 	Scheme      string             `json:"scheme,omitempty" yaml:"scheme,omitempty"`


### PR DESCRIPTION
Address issues:
https://github.com/rancher/rancher/issues/20749
https://github.com/rancher/rancher/issues/19992

Problem:
On redeploy/UI update, httpGet.host in yaml manifest is removed.

Solution:
Bring it back in API scheme

The Host header in `HTTPHeaders` field can be a substitute for it, but we probably shouldn't break existing manifests using the `host` field.
