### PR TITLE
Add ScalingLimited condition to status map

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -74,6 +74,7 @@ var reverseErrorMap = map[string]bool{
 	"KernelHasNoDeadlock": true,
 	"Unschedulable":       true,
 	"ReplicaFailure":      true,
+	"ScalingLimited":      true,
 }
 
 // True ==


### PR DESCRIPTION
The hpa condition ScalingLimited should be in reverseErrorMap.
It means the the hps object is currently not able to scale due to
the scaling speed is too high.

Related issue:
https://github.com/rancher/rancher/issues/20955