### PR TITLE
Remove scaling limited from error map

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -74,7 +74,6 @@ var reverseErrorMap = map[string]bool{
 	"KernelHasNoDeadlock": true,
 	"Unschedulable":       true,
 	"ReplicaFailure":      true,
-	"ScalingLimited":      true,
 }
 
 // True ==


### PR DESCRIPTION
**Problem:**
The `ScalingLimited` will set to true when the target workload's
cpu useage is zero.
In this case, we should not set state to error.

**Solution:**
Remove `ScalingLimited` from reverseErrorMap.

Related issue: 
https://github.com/rancher/rancher/issues/20955