### PR TITLE
Use norman struct tags for limits of nodepool timeout

### DIFF
--- a/apis/management.cattle.io/v3/machine_types.go
+++ b/apis/management.cattle.io/v3/machine_types.go
@@ -157,7 +157,7 @@ type NodePoolSpec struct {
 	DisplayName string `json:"displayName"`
 	ClusterName string `json:"clusterName,omitempty" norman:"type=reference[cluster],noupdate,required"`
 
-	DeleteNotReadyAfterSecs time.Duration `json:"deleteNotReadyAfterSecs" norman:"default=0"`
+	DeleteNotReadyAfterSecs time.Duration `json:"deleteNotReadyAfterSecs" norman:"default=0,max=9223372036854775807,min=0"`
 }
 
 type NodePoolStatus struct {


### PR DESCRIPTION
Extreme values could overflow nodepool timeout int64 value. Now, it will
return an error for values > maxInt64 or less than 0.

Addresses: https://github.com/rancher/rancher/issues/21431