### PR TITLE
Modify norman struct tag to be 1 year in seconds

### DIFF
--- a/apis/management.cattle.io/v3/machine_types.go
+++ b/apis/management.cattle.io/v3/machine_types.go
@@ -157,7 +157,7 @@ type NodePoolSpec struct {
 	DisplayName string `json:"displayName"`
 	ClusterName string `json:"clusterName,omitempty" norman:"type=reference[cluster],noupdate,required"`
 
-	DeleteNotReadyAfterSecs time.Duration `json:"deleteNotReadyAfterSecs" norman:"default=0,max=9223372036854775807,min=0"`
+	DeleteNotReadyAfterSecs time.Duration `json:"deleteNotReadyAfterSecs" norman:"default=0,max=31540000,min=0"`
 }
 
 type NodePoolStatus struct {


### PR DESCRIPTION
Javascript only supports a max int of 2^53 so very large values
can cause errors.

Instead, use the max value of a year in seconds for node timeout limit

Addresses: https://github.com/rancher/rancher/issues/21431