### PR TITLE
bump pipeline-tools image to v0.1.11

### DIFF
--- a/apis/management.cattle.io/v3/tools_system_images.go
+++ b/apis/management.cattle.io/v3/tools_system_images.go
@@ -21,12 +21,12 @@ var (
 		PipelineSystemImages: projectv3.PipelineSystemImages{
 			Jenkins:       m("rancher/pipeline-jenkins-server:v0.1.0"),
 			JenkinsJnlp:   m("jenkins/jnlp-slave:3.10-1-alpine"),
-			AlpineGit:     m("rancher/pipeline-tools:v0.1.10"),
+			AlpineGit:     m("rancher/pipeline-tools:v0.1.11"),
 			PluginsDocker: m("plugins/docker:17.12"),
 			Minio:         m("minio/minio:RELEASE.2018-05-25T19-49-13Z"),
 			Registry:      m("registry:2"),
-			RegistryProxy: m("rancher/pipeline-tools:v0.1.10"),
-			KubeApply:     m("rancher/pipeline-tools:v0.1.10"),
+			RegistryProxy: m("rancher/pipeline-tools:v0.1.11"),
+			KubeApply:     m("rancher/pipeline-tools:v0.1.11"),
 		},
 		LoggingSystemImages: LoggingSystemImages{
 			Fluentd:                       m("rancher/fluentd:v0.1.11"),


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/21282

Depend on this [pr](https://github.com/rancher/pipeline-tools/pull/15) and a new pipeline-tools image release.
