### PR TITLE
Revision name changes

### DIFF
--- a/apis/management.cattle.io/v3/cluster_template_types.go
+++ b/apis/management.cattle.io/v3/cluster_template_types.go
@@ -37,6 +37,7 @@ type ClusterTemplateRevision struct {
 }
 
 type ClusterTemplateRevisionSpec struct {
+	DisplayName         string `json:"displayName" norman:"required"`
 	Enabled             *bool  `json:"enabled,omitempty" norman:"default=true"`
 	ClusterTemplateName string `json:"clusterTemplateName,omitempty" norman:"type=reference[clusterTemplate],required,noupdate"`
 

--- a/apis/management.cattle.io/v3/schema/schema.go
+++ b/apis/management.cattle.io/v3/schema/schema.go
@@ -867,7 +867,7 @@ func clusterTemplateTypes(schemas *types.Schemas) *types.Schemas {
 		TypeName("clusterTemplate", v3.ClusterTemplate{}).
 		TypeName("clusterTemplateRevision", v3.ClusterTemplateRevision{}).
 		AddMapperForType(&Version, v3.ClusterTemplate{}, m.Drop{Field: "namespaceId"}, m.DisplayName{}).
-		AddMapperForType(&Version, v3.ClusterTemplateRevision{}, m.Drop{Field: "namespaceId"}).
+		AddMapperForType(&Version, v3.ClusterTemplateRevision{}, m.Drop{Field: "namespaceId"}, m.DisplayName{}).
 		MustImport(&Version, v3.ClusterTemplateQuestionsOutput{}).
 		MustImport(&Version, v3.ClusterTemplate{}).
 		MustImportAndCustomize(&Version, v3.ClusterTemplateRevision{}, func(schema *types.Schema) {

--- a/client/management/v3/zz_generated_cluster_template_revision_spec.go
+++ b/client/management/v3/zz_generated_cluster_template_revision_spec.go
@@ -4,6 +4,7 @@ const (
 	ClusterTemplateRevisionSpecType                   = "clusterTemplateRevisionSpec"
 	ClusterTemplateRevisionSpecFieldClusterConfig     = "clusterConfig"
 	ClusterTemplateRevisionSpecFieldClusterTemplateID = "clusterTemplateId"
+	ClusterTemplateRevisionSpecFieldDisplayName       = "displayName"
 	ClusterTemplateRevisionSpecFieldEnabled           = "enabled"
 	ClusterTemplateRevisionSpecFieldQuestions         = "questions"
 )
@@ -11,6 +12,7 @@ const (
 type ClusterTemplateRevisionSpec struct {
 	ClusterConfig     *ClusterSpecBase `json:"clusterConfig,omitempty" yaml:"clusterConfig,omitempty"`
 	ClusterTemplateID string           `json:"clusterTemplateId,omitempty" yaml:"clusterTemplateId,omitempty"`
+	DisplayName       string           `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	Enabled           *bool            `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 	Questions         []Question       `json:"questions,omitempty" yaml:"questions,omitempty"`
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/22185
https://github.com/rancher/rancher/issues/21893

ClusterTemplateRevision name is now non-unique and required field.