### PR TITLE
Bump pipeine-tools to v0.1.12

### DIFF
--- a/apis/management.cattle.io/v3/tools_system_images.go
+++ b/apis/management.cattle.io/v3/tools_system_images.go
@@ -21,12 +21,12 @@ var (
 		PipelineSystemImages: projectv3.PipelineSystemImages{
 			Jenkins:       m("rancher/pipeline-jenkins-server:v0.1.3"),
 			JenkinsJnlp:   m("jenkins/jnlp-slave:3.10-1-alpine"),
-			AlpineGit:     m("rancher/pipeline-tools:v0.1.11"),
+			AlpineGit:     m("rancher/pipeline-tools:v0.1.12"),
 			PluginsDocker: m("plugins/docker:17.12"),
 			Minio:         m("minio/minio:RELEASE.2018-05-25T19-49-13Z"),
 			Registry:      m("registry:2"),
-			RegistryProxy: m("rancher/pipeline-tools:v0.1.11"),
-			KubeApply:     m("rancher/pipeline-tools:v0.1.11"),
+			RegistryProxy: m("rancher/pipeline-tools:v0.1.12"),
+			KubeApply:     m("rancher/pipeline-tools:v0.1.12"),
 		},
 		LoggingSystemImages: LoggingSystemImages{
 			Fluentd:                       m("rancher/fluentd:v0.1.11"),


### PR DESCRIPTION
Related issue: https://github.com/rancher/rancher/issues/22057
Depend on https://github.com/rancher/pipeline-tools/pull/16 and the new pipeline-tools release.