### PR TITLE
Add SendResolved field to Notifier

### DIFF
--- a/apis/management.cattle.io/v3/alerting_types.go
+++ b/apis/management.cattle.io/v3/alerting_types.go
@@ -262,6 +262,7 @@ type NotifierSpec struct {
 
 	DisplayName     string           `json:"displayName,omitempty" norman:"required"`
 	Description     string           `json:"description,omitempty"`
+	SendResolved    bool             `json:"sendResolved,omitempty"`
 	SMTPConfig      *SMTPConfig      `json:"smtpConfig,omitempty"`
 	SlackConfig     *SlackConfig     `json:"slackConfig,omitempty"`
 	PagerdutyConfig *PagerdutyConfig `json:"pagerdutyConfig,omitempty"`

--- a/client/management/v3/zz_generated_notifier.go
+++ b/client/management/v3/zz_generated_notifier.go
@@ -18,6 +18,7 @@ const (
 	NotifierFieldPagerdutyConfig      = "pagerdutyConfig"
 	NotifierFieldRemoved              = "removed"
 	NotifierFieldSMTPConfig           = "smtpConfig"
+	NotifierFieldSendResolved         = "sendResolved"
 	NotifierFieldSlackConfig          = "slackConfig"
 	NotifierFieldState                = "state"
 	NotifierFieldStatus               = "status"
@@ -42,6 +43,7 @@ type Notifier struct {
 	PagerdutyConfig      *PagerdutyConfig  `json:"pagerdutyConfig,omitempty" yaml:"pagerdutyConfig,omitempty"`
 	Removed              string            `json:"removed,omitempty" yaml:"removed,omitempty"`
 	SMTPConfig           *SMTPConfig       `json:"smtpConfig,omitempty" yaml:"smtpConfig,omitempty"`
+	SendResolved         bool              `json:"sendResolved,omitempty" yaml:"sendResolved,omitempty"`
 	SlackConfig          *SlackConfig      `json:"slackConfig,omitempty" yaml:"slackConfig,omitempty"`
 	State                string            `json:"state,omitempty" yaml:"state,omitempty"`
 	Status               *NotifierStatus   `json:"status,omitempty" yaml:"status,omitempty"`

--- a/client/management/v3/zz_generated_notifier_spec.go
+++ b/client/management/v3/zz_generated_notifier_spec.go
@@ -7,6 +7,7 @@ const (
 	NotifierSpecFieldDisplayName     = "displayName"
 	NotifierSpecFieldPagerdutyConfig = "pagerdutyConfig"
 	NotifierSpecFieldSMTPConfig      = "smtpConfig"
+	NotifierSpecFieldSendResolved    = "sendResolved"
 	NotifierSpecFieldSlackConfig     = "slackConfig"
 	NotifierSpecFieldWebhookConfig   = "webhookConfig"
 	NotifierSpecFieldWechatConfig    = "wechatConfig"
@@ -18,6 +19,7 @@ type NotifierSpec struct {
 	DisplayName     string           `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	PagerdutyConfig *PagerdutyConfig `json:"pagerdutyConfig,omitempty" yaml:"pagerdutyConfig,omitempty"`
 	SMTPConfig      *SMTPConfig      `json:"smtpConfig,omitempty" yaml:"smtpConfig,omitempty"`
+	SendResolved    bool             `json:"sendResolved,omitempty" yaml:"sendResolved,omitempty"`
 	SlackConfig     *SlackConfig     `json:"slackConfig,omitempty" yaml:"slackConfig,omitempty"`
 	WebhookConfig   *WebhookConfig   `json:"webhookConfig,omitempty" yaml:"webhookConfig,omitempty"`
 	WechatConfig    *WechatConfig    `json:"wechatConfig,omitempty" yaml:"wechatConfig,omitempty"`


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/17962

`send_resolved` is a common configuration for all kinds of notifier type.
https://prometheus.io/docs/alerting/configuration

It is set to false before.