### PR TITLE
Docker secret auth

### DIFF
--- a/apis/project.cattle.io/v3/schema/schema_secrets.go
+++ b/apis/project.cattle.io/v3/schema/schema_secrets.go
@@ -206,7 +206,7 @@ func secretTypes(schemas *types.Schemas) *types.Schemas {
 				},
 			},
 		).
-		AddMapperForType(&Version, v3.RegistryCredential{}, RegistryCredentialMapper{}).
+		AddMapperForType(&Version, v1.Secret{}, RegistryCredentialMapper{}).
 		MustImportAndCustomize(&Version, v1.Secret{}, func(schema *types.Schema) {
 			schema.MustCustomizeField("kind", func(f types.Field) types.Field {
 				f.Options = []string{

--- a/apis/project.cattle.io/v3/types.go
+++ b/apis/project.cattle.io/v3/types.go
@@ -35,6 +35,7 @@ type RegistryCredential struct {
 	Username    string `json:"username"`
 	Password    string `json:"password" norman:"writeOnly"`
 	Auth        string `json:"auth" norman:"writeOnly"`
+	Email       string `json:"email"`
 }
 
 type Certificate struct {

--- a/client/project/v3/zz_generated_registry_credential.go
+++ b/client/project/v3/zz_generated_registry_credential.go
@@ -4,6 +4,7 @@ const (
 	RegistryCredentialType             = "registryCredential"
 	RegistryCredentialFieldAuth        = "auth"
 	RegistryCredentialFieldDescription = "description"
+	RegistryCredentialFieldEmail       = "email"
 	RegistryCredentialFieldPassword    = "password"
 	RegistryCredentialFieldUsername    = "username"
 )
@@ -11,6 +12,7 @@ const (
 type RegistryCredential struct {
 	Auth        string `json:"auth,omitempty" yaml:"auth,omitempty"`
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Email       string `json:"email,omitempty" yaml:"email,omitempty"`
 	Password    string `json:"password,omitempty" yaml:"password,omitempty"`
 	Username    string `json:"username,omitempty" yaml:"username,omitempty"`
 }


### PR DESCRIPTION
- Mapper should be invoked for v1.Secret type so that the "auth" field gets generated for dockerCedential
- Support "email" field in DockerCredential