### PR TITLE
set name annotation if name is empty

### DIFF
--- a/mapper/credentialmapper.go
+++ b/mapper/credentialmapper.go
@@ -14,11 +14,11 @@ type CredentialMapper struct {
 
 func (s CredentialMapper) FromInternal(data map[string]interface{}) {
 	formatData(data)
-	name := convert.ToString(values.GetValueN(data, "name"))
+	name := convert.ToString(values.GetValueN(data, "field.cattle.io/name"))
 	if name == "" {
 		id := convert.ToString(values.GetValueN(data, "id"))
 		if id != "" {
-			data["name"] = id
+			data["field.cattle.io/name"] = id
 		}
 	}
 	delete(data, "data")


### PR DESCRIPTION
Issue: setting name doesn't work, because annotation_field mapper overrides the name with field.cattle.io/name value

https://github.com/rancher/rancher/issues/22832