### PR TITLE
Update pipeline tools to 0.1.13 for cli 2.3.0-rc7

### DIFF
--- a/apis/management.cattle.io/v3/tools_system_images.go
+++ b/apis/management.cattle.io/v3/tools_system_images.go
@@ -15,12 +15,12 @@ var (
 		PipelineSystemImages: projectv3.PipelineSystemImages{
 			Jenkins:       m("rancher/pipeline-jenkins-server:v0.1.4"),
 			JenkinsJnlp:   m("jenkins/jnlp-slave:3.10-1-alpine"),
-			AlpineGit:     m("rancher/pipeline-tools:v0.1.12"),
+			AlpineGit:     m("rancher/pipeline-tools:v0.1.13"),
 			PluginsDocker: m("plugins/docker:17.12"),
 			Minio:         m("minio/minio:RELEASE.2018-05-25T19-49-13Z"),
 			Registry:      m("registry:2"),
-			RegistryProxy: m("rancher/pipeline-tools:v0.1.12"),
-			KubeApply:     m("rancher/pipeline-tools:v0.1.12"),
+			RegistryProxy: m("rancher/pipeline-tools:v0.1.13"),
+			KubeApply:     m("rancher/pipeline-tools:v0.1.13"),
 		},
 		AuthSystemImages: AuthSystemImages{
 			KubeAPIAuth: m("rancher/kube-api-auth:v0.1.3"),


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/22164
Depend on pipeline-tools v0.1.13 with https://github.com/rancher/pipeline-tools/pull/17