### PR TITLE
Change the json-tag of WindowsPodInfraContainer in RKESystemImages 

### DIFF
--- a/apis/management.cattle.io/v3/rke_types.go
+++ b/apis/management.cattle.io/v3/rke_types.go
@@ -147,7 +147,7 @@ type RKESystemImages struct {
 	// Metrics Server image
 	MetricsServer string `yaml:"metrics_server" json:"metricsServer,omitempty"`
 	// Pod infra container image for Windows
-	WindowsPodInfraContainer string `yaml:"windows_pod_infra_container" json:"podInfraWindowsContainer,omitempty"`
+	WindowsPodInfraContainer string `yaml:"windows_pod_infra_container" json:"windowsPodInfraContainer,omitempty"`
 }
 
 type RKEConfigNode struct {

--- a/client/management/v3/zz_generated_rke_system_images.go
+++ b/client/management/v3/zz_generated_rke_system_images.go
@@ -31,7 +31,7 @@ const (
 	RKESystemImagesFieldPodInfraContainer         = "podInfraContainer"
 	RKESystemImagesFieldWeaveCNI                  = "weaveCni"
 	RKESystemImagesFieldWeaveNode                 = "weaveNode"
-	RKESystemImagesFieldWindowsPodInfraContainer  = "podInfraWindowsContainer"
+	RKESystemImagesFieldWindowsPodInfraContainer  = "windowsPodInfraContainer"
 )
 
 type RKESystemImages struct {
@@ -64,5 +64,5 @@ type RKESystemImages struct {
 	PodInfraContainer         string `json:"podInfraContainer,omitempty" yaml:"podInfraContainer,omitempty"`
 	WeaveCNI                  string `json:"weaveCni,omitempty" yaml:"weaveCni,omitempty"`
 	WeaveNode                 string `json:"weaveNode,omitempty" yaml:"weaveNode,omitempty"`
-	WindowsPodInfraContainer  string `json:"podInfraWindowsContainer,omitempty" yaml:"podInfraWindowsContainer,omitempty"`
+	WindowsPodInfraContainer  string `json:"windowsPodInfraContainer,omitempty" yaml:"windowsPodInfraContainer,omitempty"`
 }


### PR DESCRIPTION
**Problem:**
On air-gapped, the private registry could not apply to the pause image
of Windows kubelet. It seems the decoding of [mapstructure](github.com/mitchellh/mapstructure) doesn't
respect the json tag of the struct definition:
https://github.com/rancher/rancher/blob/0ba3fd34cc5bbbfda74449daa3b864f436a9f0ec/pkg/controllers/management/clusterprovisioner/provisioner.go#L751-L764

**Solution:**
Correct the json-tag

**Issue:**
https://github.com/rancher/rancher/issues/23000