### PR TITLE
RFC/PREP: Allow a load-balancer address for k8s API

### DIFF
--- a/apis/management.cattle.io/v3/rke_types.go
+++ b/apis/management.cattle.io/v3/rke_types.go
@@ -47,6 +47,8 @@ type RancherKubernetesEngineConfig struct {
 	AddonJobTimeout int `yaml:"addon_job_timeout" json:"addonJobTimeout,omitempty" norman:"default=30"`
 	// Bastion/Jump Host configuration
 	BastionHost BastionHost `yaml:"bastion_host" json:"bastionHost,omitempty"`
+	// Load Balancer address (externally-managed) through which nodes are to contact the control plane API port
+	ControlPlaneLoadBalancer string `yaml:"control_plane_load_balancer" json:"controlPlaneLoadBalancer,omitempty"`
 	// Monitoring Config
 	Monitoring MonitoringConfig `yaml:"monitoring" json:"monitoring,omitempty"`
 	// RestoreCluster flag


### PR DESCRIPTION
Extends the RancherKubernetesEngineConfig (cluster.yml) type to support the configuration of an API load-balancer.

This is a pre-requisite for an upcoming PR to extend RKE to support such a configuration.

to-do:

- [ ] update and document design in accordance w/ feedback from #1348

--

This optional string is to replace the hostname used by other nodes and
configurations when attempting contacting the k8s API service.

It is expected to be the hostname of a layer-4 (TCP) load-balancer which
will be externally configured by the organisation to direct traffic to
an appropriate selection of the cluster's ControlPlane nodes on the same
port as it arrived; i.e. TCP/6443 for kube-apiserver.

Any TLS configuration and healthchecks on the load-balancer host are
also expected to be managed by the organisation.