### PR TITLE
Add field to ingress config to accept additional env vars

### DIFF
--- a/apis/management.cattle.io/v3/rke_types.go
+++ b/apis/management.cattle.io/v3/rke_types.go
@@ -370,6 +370,8 @@ type IngressConfig struct {
 	ExtraArgs map[string]string `yaml:"extra_args" json:"extraArgs,omitempty"`
 	// DNS Policy
 	DNSPolicy string `yaml:"dns_policy" json:"dnsPolicy,omitempty"`
+	// extra env vars
+	ExtraEnv []string `yaml:"extra_env" json:"extraEnv,omitempty"`
 }
 
 type RKEPlan struct {

--- a/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -4014,6 +4014,11 @@ func (in *IngressConfig) DeepCopyInto(out *IngressConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.ExtraEnv != nil {
+		in, out := &in.ExtraEnv, &out.ExtraEnv
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/client/management/v3/zz_generated_ingress_config.go
+++ b/client/management/v3/zz_generated_ingress_config.go
@@ -4,6 +4,7 @@ const (
 	IngressConfigType              = "ingressConfig"
 	IngressConfigFieldDNSPolicy    = "dnsPolicy"
 	IngressConfigFieldExtraArgs    = "extraArgs"
+	IngressConfigFieldExtraEnv     = "extraEnv"
 	IngressConfigFieldNodeSelector = "nodeSelector"
 	IngressConfigFieldOptions      = "options"
 	IngressConfigFieldProvider     = "provider"
@@ -12,6 +13,7 @@ const (
 type IngressConfig struct {
 	DNSPolicy    string            `json:"dnsPolicy,omitempty" yaml:"dnsPolicy,omitempty"`
 	ExtraArgs    map[string]string `json:"extraArgs,omitempty" yaml:"extraArgs,omitempty"`
+	ExtraEnv     []string          `json:"extraEnv,omitempty" yaml:"extraEnv,omitempty"`
 	NodeSelector map[string]string `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty"`
 	Options      map[string]string `json:"options,omitempty" yaml:"options,omitempty"`
 	Provider     string            `json:"provider,omitempty" yaml:"provider,omitempty"`


### PR DESCRIPTION
User can pass any required env vars through this new field to the nginx ingress controller
https://github.com/rancher/rancher/issues/16868