### PR TITLE
Use default mapper for hostport conversion

### DIFF
--- a/mapper/container_ports.go
+++ b/mapper/container_ports.go
@@ -98,13 +98,11 @@ func (n ContainerPorts) ToInternal(data map[string]interface{}) error {
 					logrus.Warnf("Failed to encode port: %v", err)
 					return obj
 				}
-				if strings.EqualFold(convert.ToString(mapped["kind"]), "HostPort") {
-					if _, ok := mapped["sourcePort"]; ok {
-						mapped["hostPort"] = mapped["sourcePort"]
-					}
+				if !strings.EqualFold(convert.ToString(mapped["kind"]), "HostPort") {
+					// delete the source port so it doesn't get converted to the host port by default mapper
+					delete(mapped, "sourcePort")
 				}
-				// delete the source port so it doesn't get converted to the host port by default mapper
-				delete(mapped, "sourcePort")
+
 			}
 			ports = append(ports, l)
 		}


### PR DESCRIPTION
To address https://github.com/rancher/rancher/issues/23375#issuecomment-550438582


* For hostPort port type, the sourcePort->hostPort conversion will be done by default mapper (as a reverse for https://github.com/rancher/types/blob/master/apis/project.cattle.io/v3/schema/schema.go#L517)
* For any other port, sourcePort will be dropped https://github.com/rancher/types/compare/release/v2.3...alena1108:nov6?expand=1#diff-8d858d11bc93015c62cc81c1f203550bR103 so the conversion doesn't happen