### PR TITLE
Update notifier fields type

### DIFF
--- a/apis/management.cattle.io/v3/alerting_types.go
+++ b/apis/management.cattle.io/v3/alerting_types.go
@@ -283,7 +283,7 @@ type SMTPConfig struct {
 	Host             string `json:"host,omitempty" norman:"required,type=hostname"`
 	Port             int    `json:"port,omitempty" norman:"required,min=1,max=65535,default=587"`
 	Username         string `json:"username,omitempty"`
-	Password         string `json:"password,omitempty"`
+	Password         string `json:"password,omitempty" norman:"type=password"`
 	Sender           string `json:"sender,omitempty" norman:"required"`
 	DefaultRecipient string `json:"defaultRecipient,omitempty" norman:"required"`
 	TLS              bool   `json:"tls,omitempty" norman:"required,default=true"`


### PR DESCRIPTION
Problem: Notifier email configure return plaintext password
Solution: update type to password
Issue: https://github.com/rancher/rancher/issues/24335
Related PR: https://github.com/rancher/rancher/pull/24477