### PR TITLE
Do not drop source and host port

### DIFF
--- a/apis/project.cattle.io/v3/schema/schema.go
+++ b/apis/project.cattle.io/v3/schema/schema.go
@@ -514,8 +514,6 @@ func podTypes(schemas *types.Schemas) *types.Schemas {
 		).
 		AddMapperForType(&Version, v1.ContainerPort{},
 			m.Move{From: "hostIP", To: "hostIp"},
-			m.Copy{From: "hostPort", To: "sourcePort"},
-			m.Drop{Field: "hostPort"},
 		).
 		AddMapperForType(&Version, v1.Handler{},
 			mapper.ContainerProbeHandler{}).

--- a/client/project/v3/zz_generated_container_port.go
+++ b/client/project/v3/zz_generated_container_port.go
@@ -5,18 +5,20 @@ const (
 	ContainerPortFieldContainerPort = "containerPort"
 	ContainerPortFieldDNSName       = "dnsName"
 	ContainerPortFieldHostIp        = "hostIp"
-	ContainerPortFieldHostPort      = "sourcePort"
+	ContainerPortFieldHostPort      = "hostPort"
 	ContainerPortFieldKind          = "kind"
 	ContainerPortFieldName          = "name"
 	ContainerPortFieldProtocol      = "protocol"
+	ContainerPortFieldSourcePort    = "sourcePort"
 )
 
 type ContainerPort struct {
 	ContainerPort int64  `json:"containerPort,omitempty" yaml:"containerPort,omitempty"`
 	DNSName       string `json:"dnsName,omitempty" yaml:"dnsName,omitempty"`
 	HostIp        string `json:"hostIp,omitempty" yaml:"hostIp,omitempty"`
-	HostPort      int64  `json:"sourcePort,omitempty" yaml:"sourcePort,omitempty"`
+	HostPort      int64  `json:"hostPort,omitempty" yaml:"hostPort,omitempty"`
 	Kind          string `json:"kind,omitempty" yaml:"kind,omitempty"`
 	Name          string `json:"name,omitempty" yaml:"name,omitempty"`
 	Protocol      string `json:"protocol,omitempty" yaml:"protocol,omitempty"`
+	SourcePort    int64  `json:"sourcePort,omitempty" yaml:"sourcePort,omitempty"`
 }

--- a/mapper/container_ports.go
+++ b/mapper/container_ports.go
@@ -66,14 +66,13 @@ func (n ContainerPorts) FromInternal(data map[string]interface{}) {
 			if annotationPort, ok := portMap[convert.ToString(portName)]; ok {
 				containerPorts = append(containerPorts, annotationPort)
 			} else {
-				hostPort, _ := values.GetValue(asMap, "sourcePort")
+				hostPort, _ := values.GetValue(asMap, "hostPort")
 				if hostPort == nil {
 					asMap["kind"] = "ClusterIP"
 				} else {
 					asMap["sourcePort"] = hostPort
 					asMap["kind"] = "HostPort"
 				}
-				delete(asMap, "hostPort")
 				containerPorts = append(containerPorts, asMap)
 			}
 		}
@@ -98,11 +97,9 @@ func (n ContainerPorts) ToInternal(data map[string]interface{}) error {
 					logrus.Warnf("Failed to encode port: %v", err)
 					return obj
 				}
-				if !strings.EqualFold(convert.ToString(mapped["kind"]), "HostPort") {
-					// delete the source port so it doesn't get converted to the host port by default mapper
-					delete(mapped, "sourcePort")
+				if strings.EqualFold(convert.ToString(mapped["kind"]), "HostPort") {
+					mapped["hostPort"] = mapped["sourcePort"]
 				}
-
 			}
 			ports = append(ports, l)
 		}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/24551
https://github.com/rancher/rancher/issues/24358

To preserve `annotation to field mapper` logic as well as natively created object to Rancher API, dropping hostPort is tricky. We'll just leave it exposed in rancher api (UI would just ignore it). In host port service use case the sourcePort set by the UI will be translated to the hostPort respected by k8s