### PR TITLE
Added redeploy to workload api actions

### DIFF
--- a/apis/project.cattle.io/v3/schema/schema.go
+++ b/apis/project.cattle.io/v3/schema/schema.go
@@ -123,8 +123,9 @@ func workloadTypes(schemas *types.Schemas) *types.Schemas {
 				"rollback": {
 					Input: "rollbackRevision",
 				},
-				"pause":  {},
-				"resume": {},
+				"pause":    {},
+				"resume":   {},
+				"redeploy": {},
 			}
 			schema.MustCustomizeField("name", func(field types.Field) types.Field {
 				field.Type = "dnsLabelRestricted"
@@ -182,6 +183,9 @@ func statefulSetTypes(schemas *types.Schemas) *types.Schemas {
 		MustImport(&Version, k8sappv1.StatefulSetSpec{}, statefulSetConfigOverride{}).
 		MustImportAndCustomize(&Version, k8sappv1.StatefulSet{}, func(schema *types.Schema) {
 			schema.BaseType = "workload"
+			schema.ResourceActions = map[string]types.Action{
+				"redeploy": {},
+			}
 			schema.MustCustomizeField("name", func(field types.Field) types.Field {
 				field.Type = "dnsLabelRestricted"
 				field.Nullable = false
@@ -218,6 +222,9 @@ func replicaSetTypes(schemas *types.Schemas) *types.Schemas {
 		MustImport(&Version, appsv1.ReplicaSetSpec{}, replicaSetConfigOverride{}).
 		MustImportAndCustomize(&Version, appsv1.ReplicaSet{}, func(schema *types.Schema) {
 			schema.BaseType = "workload"
+			schema.ResourceActions = map[string]types.Action{
+				"redeploy": {},
+			}
 			schema.MustCustomizeField("name", func(field types.Field) types.Field {
 				field.Type = "dnsLabelRestricted"
 				field.Nullable = false
@@ -256,6 +263,9 @@ func replicationControllerTypes(schemas *types.Schemas) *types.Schemas {
 			schema.BaseType = "workload"
 			schema.CollectionMethods = []string{http.MethodGet}
 			schema.ResourceMethods = []string{http.MethodGet}
+			schema.ResourceActions = map[string]types.Action{
+				"redeploy": {},
+			}
 			schema.MustCustomizeField("name", func(field types.Field) types.Field {
 				field.Type = "dnsLabelRestricted"
 				field.Nullable = false
@@ -302,6 +312,9 @@ func daemonSetTypes(schemas *types.Schemas) *types.Schemas {
 		MustImport(&Version, k8sappv1.DaemonSetSpec{}, daemonSetOverride{}).
 		MustImportAndCustomize(&Version, k8sappv1.DaemonSet{}, func(schema *types.Schema) {
 			schema.BaseType = "workload"
+			schema.ResourceActions = map[string]types.Action{
+				"redeploy": {},
+			}
 			schema.MustCustomizeField("name", func(field types.Field) types.Field {
 				field.Type = "dnsLabelRestricted"
 				field.Nullable = false
@@ -408,6 +421,9 @@ func cronJobTypes(schemas *types.Schemas) *types.Schemas {
 		MustImport(&Version, batchv1beta1.JobTemplateSpec{}).
 		MustImportAndCustomize(&Version, batchv1beta1.CronJob{}, func(schema *types.Schema) {
 			schema.BaseType = "workload"
+			schema.ResourceActions = map[string]types.Action{
+				"redeploy": {},
+			}
 			schema.MustCustomizeField("name", func(field types.Field) types.Field {
 				field.Type = "dnsLabelRestricted"
 				field.Nullable = false
@@ -469,8 +485,9 @@ func deploymentTypes(schemas *types.Schemas) *types.Schemas {
 				"rollback": {
 					Input: "deploymentRollbackInput",
 				},
-				"pause":  {},
-				"resume": {},
+				"pause":    {},
+				"resume":   {},
+				"redeploy": {},
 			}
 			schema.MustCustomizeField("name", func(field types.Field) types.Field {
 				field.Type = "dnsLabelRestricted"

--- a/client/project/v3/zz_generated_cron_job.go
+++ b/client/project/v3/zz_generated_cron_job.go
@@ -137,6 +137,8 @@ type CronJobOperations interface {
 	Replace(existing *CronJob) (*CronJob, error)
 	ByID(id string) (*CronJob, error)
 	Delete(container *CronJob) error
+
+	ActionRedeploy(resource *CronJob) error
 }
 
 func newCronJobClient(apiClient *Client) *CronJobClient {
@@ -188,4 +190,9 @@ func (c *CronJobClient) ByID(id string) (*CronJob, error) {
 
 func (c *CronJobClient) Delete(container *CronJob) error {
 	return c.apiClient.Ops.DoResourceDelete(CronJobType, &container.Resource)
+}
+
+func (c *CronJobClient) ActionRedeploy(resource *CronJob) error {
+	err := c.apiClient.Ops.DoAction(CronJobType, "redeploy", &resource.Resource, nil, nil)
+	return err
 }

--- a/client/project/v3/zz_generated_daemon_set.go
+++ b/client/project/v3/zz_generated_daemon_set.go
@@ -135,6 +135,8 @@ type DaemonSetOperations interface {
 	Replace(existing *DaemonSet) (*DaemonSet, error)
 	ByID(id string) (*DaemonSet, error)
 	Delete(container *DaemonSet) error
+
+	ActionRedeploy(resource *DaemonSet) error
 }
 
 func newDaemonSetClient(apiClient *Client) *DaemonSetClient {
@@ -186,4 +188,9 @@ func (c *DaemonSetClient) ByID(id string) (*DaemonSet, error) {
 
 func (c *DaemonSetClient) Delete(container *DaemonSet) error {
 	return c.apiClient.Ops.DoResourceDelete(DaemonSetType, &container.Resource)
+}
+
+func (c *DaemonSetClient) ActionRedeploy(resource *DaemonSet) error {
+	err := c.apiClient.Ops.DoAction(DaemonSetType, "redeploy", &resource.Resource, nil, nil)
+	return err
 }

--- a/client/project/v3/zz_generated_deployment.go
+++ b/client/project/v3/zz_generated_deployment.go
@@ -142,6 +142,8 @@ type DeploymentOperations interface {
 
 	ActionPause(resource *Deployment) error
 
+	ActionRedeploy(resource *Deployment) error
+
 	ActionResume(resource *Deployment) error
 
 	ActionRollback(resource *Deployment, input *DeploymentRollbackInput) error
@@ -200,6 +202,11 @@ func (c *DeploymentClient) Delete(container *Deployment) error {
 
 func (c *DeploymentClient) ActionPause(resource *Deployment) error {
 	err := c.apiClient.Ops.DoAction(DeploymentType, "pause", &resource.Resource, nil, nil)
+	return err
+}
+
+func (c *DeploymentClient) ActionRedeploy(resource *Deployment) error {
+	err := c.apiClient.Ops.DoAction(DeploymentType, "redeploy", &resource.Resource, nil, nil)
 	return err
 }
 

--- a/client/project/v3/zz_generated_replica_set.go
+++ b/client/project/v3/zz_generated_replica_set.go
@@ -137,6 +137,8 @@ type ReplicaSetOperations interface {
 	Replace(existing *ReplicaSet) (*ReplicaSet, error)
 	ByID(id string) (*ReplicaSet, error)
 	Delete(container *ReplicaSet) error
+
+	ActionRedeploy(resource *ReplicaSet) error
 }
 
 func newReplicaSetClient(apiClient *Client) *ReplicaSetClient {
@@ -188,4 +190,9 @@ func (c *ReplicaSetClient) ByID(id string) (*ReplicaSet, error) {
 
 func (c *ReplicaSetClient) Delete(container *ReplicaSet) error {
 	return c.apiClient.Ops.DoResourceDelete(ReplicaSetType, &container.Resource)
+}
+
+func (c *ReplicaSetClient) ActionRedeploy(resource *ReplicaSet) error {
+	err := c.apiClient.Ops.DoAction(ReplicaSetType, "redeploy", &resource.Resource, nil, nil)
+	return err
 }

--- a/client/project/v3/zz_generated_replication_controller.go
+++ b/client/project/v3/zz_generated_replication_controller.go
@@ -137,6 +137,8 @@ type ReplicationControllerOperations interface {
 	Replace(existing *ReplicationController) (*ReplicationController, error)
 	ByID(id string) (*ReplicationController, error)
 	Delete(container *ReplicationController) error
+
+	ActionRedeploy(resource *ReplicationController) error
 }
 
 func newReplicationControllerClient(apiClient *Client) *ReplicationControllerClient {
@@ -188,4 +190,9 @@ func (c *ReplicationControllerClient) ByID(id string) (*ReplicationController, e
 
 func (c *ReplicationControllerClient) Delete(container *ReplicationController) error {
 	return c.apiClient.Ops.DoResourceDelete(ReplicationControllerType, &container.Resource)
+}
+
+func (c *ReplicationControllerClient) ActionRedeploy(resource *ReplicationController) error {
+	err := c.apiClient.Ops.DoAction(ReplicationControllerType, "redeploy", &resource.Resource, nil, nil)
+	return err
 }

--- a/client/project/v3/zz_generated_stateful_set.go
+++ b/client/project/v3/zz_generated_stateful_set.go
@@ -137,6 +137,8 @@ type StatefulSetOperations interface {
 	Replace(existing *StatefulSet) (*StatefulSet, error)
 	ByID(id string) (*StatefulSet, error)
 	Delete(container *StatefulSet) error
+
+	ActionRedeploy(resource *StatefulSet) error
 }
 
 func newStatefulSetClient(apiClient *Client) *StatefulSetClient {
@@ -188,4 +190,9 @@ func (c *StatefulSetClient) ByID(id string) (*StatefulSet, error) {
 
 func (c *StatefulSetClient) Delete(container *StatefulSet) error {
 	return c.apiClient.Ops.DoResourceDelete(StatefulSetType, &container.Resource)
+}
+
+func (c *StatefulSetClient) ActionRedeploy(resource *StatefulSet) error {
+	err := c.apiClient.Ops.DoAction(StatefulSetType, "redeploy", &resource.Resource, nil, nil)
+	return err
 }

--- a/client/project/v3/zz_generated_workload.go
+++ b/client/project/v3/zz_generated_workload.go
@@ -168,6 +168,8 @@ type WorkloadOperations interface {
 
 	ActionPause(resource *Workload) error
 
+	ActionRedeploy(resource *Workload) error
+
 	ActionResume(resource *Workload) error
 
 	ActionRollback(resource *Workload, input *RollbackRevision) error
@@ -226,6 +228,11 @@ func (c *WorkloadClient) Delete(container *Workload) error {
 
 func (c *WorkloadClient) ActionPause(resource *Workload) error {
 	err := c.apiClient.Ops.DoAction(WorkloadType, "pause", &resource.Resource, nil, nil)
+	return err
+}
+
+func (c *WorkloadClient) ActionRedeploy(resource *Workload) error {
+	err := c.apiClient.Ops.DoAction(WorkloadType, "redeploy", &resource.Resource, nil, nil)
 	return err
 }
 


### PR DESCRIPTION
Added redeploy API to workload which set the timestamp to the current time.

Related issue: https://github.com/rancher/rancher/issues/23053