### PR TITLE
support secret-name and secret-namespace for vSphere cloud provider

### DIFF
--- a/apis/management.cattle.io/v3/rke_types.go
+++ b/apis/management.cattle.io/v3/rke_types.go
@@ -563,6 +563,8 @@ type VsphereCloudProvider struct {
 type GlobalVsphereOpts struct {
 	User              string `json:"user,omitempty" yaml:"user,omitempty" ini:"user,omitempty"`
 	Password          string `json:"password,omitempty" yaml:"password,omitempty" ini:"password,omitempty" norman:"type=password"`
+	SecretName        string `json:"secret-name,omitempty" yaml:"secret-name,omitempty" ini:"secret-name,omitempty"`
+	SecretNamespace   string `json:"secret-namespace,omitempty" yaml:"secret-namespace,omitempty" ini:"secret-namespace,omitempty"`
 	VCenterIP         string `json:"server,omitempty" yaml:"server,omitempty" ini:"server,omitempty"`
 	VCenterPort       string `json:"port,omitempty" yaml:"port,omitempty" ini:"port,omitempty"`
 	InsecureFlag      bool   `json:"insecure-flag,omitempty" yaml:"insecure-flag,omitempty" ini:"insecure-flag,omitempty"`
@@ -578,6 +580,8 @@ type GlobalVsphereOpts struct {
 type VirtualCenterConfig struct {
 	User              string `json:"user,omitempty" yaml:"user,omitempty" ini:"user,omitempty"`
 	Password          string `json:"password,omitempty" yaml:"password,omitempty" ini:"password,omitempty" norman:"type=password"`
+	SecretName        string `json:"secret-name,omitempty" yaml:"secret-name,omitempty" ini:"secret-name,omitempty"`
+	SecretNamespace   string `json:"secret-namespace,omitempty" yaml:"secret-namespace,omitempty" ini:"secret-namespace,omitempty"`
 	VCenterPort       string `json:"port,omitempty" yaml:"port,omitempty" ini:"port,omitempty"`
 	Datacenters       string `json:"datacenters,omitempty" yaml:"datacenters,omitempty" ini:"datacenters,omitempty"`
 	RoundTripperCount int    `json:"soap-roundtrip-count,omitempty" yaml:"soap-roundtrip-count,omitempty" ini:"soap-roundtrip-count,omitempty"`


### PR DESCRIPTION
When using https://github.com/rancher/rke it would be preferred to store the vSphere cloud provider credentials within Kubernetes as a secret rather than as plaintext on the nodes filesystem for security reasons.

The vSphere storage provider supports providing secret-name and secret-namespace as fields in the cloud provider configuration. See: https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/existing.html#supported-parameters

Rancher docs indicate that this might be supported in future. https://rancher.com/docs/rke/latest/en/config-options/cloud-providers/vsphere/config-reference/#prerequisites