### PR TITLE
Adding k8s Version and Cluster Object to Backup

### DIFF
--- a/apis/management.cattle.io/v3/backup_types.go
+++ b/apis/management.cattle.io/v3/backup_types.go
@@ -66,6 +66,10 @@ type EtcdBackupSpec struct {
 
 type EtcdBackupStatus struct {
 	Conditions []EtcdBackupCondition `json:"conditions"`
+	// version of k8s in the backup pulled from rke config
+	KubernetesVersion string `yaml:"kubernetesVersion" json:"kubernetesVersion,omitempty" norman:"noupdate"`
+	// json + gzipped + base64 backup of the cluster object when the backup was created
+	ClusterObject string `yaml:"clusterObject" json:"clusterObject,omitempty" norman:"type=password,noupdate"`
 }
 
 type EtcdBackupCondition struct {

--- a/apis/management.cattle.io/v3/cluster_types.go
+++ b/apis/management.cattle.io/v3/cluster_types.go
@@ -276,7 +276,8 @@ type MonitoringOutput struct {
 }
 
 type RestoreFromEtcdBackupInput struct {
-	EtcdBackupName string `json:"etcdBackupName,omitempty" norman:"type=reference[etcdBackup]"`
+	EtcdBackupName   string `json:"etcdBackupName,omitempty" norman:"type=reference[etcdBackup]"`
+	RestoreRkeConfig string `json:"restoreRkeConfig,omitempty"`
 }
 
 type RotateCertificateInput struct {

--- a/client/management/v3/zz_generated_etcd_backup_status.go
+++ b/client/management/v3/zz_generated_etcd_backup_status.go
@@ -1,10 +1,14 @@
 package client
 
 const (
-	EtcdBackupStatusType            = "etcdBackupStatus"
-	EtcdBackupStatusFieldConditions = "conditions"
+	EtcdBackupStatusType                   = "etcdBackupStatus"
+	EtcdBackupStatusFieldClusterObject     = "clusterObject"
+	EtcdBackupStatusFieldConditions        = "conditions"
+	EtcdBackupStatusFieldKubernetesVersion = "kubernetesVersion"
 )
 
 type EtcdBackupStatus struct {
-	Conditions []EtcdBackupCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	ClusterObject     string                `json:"clusterObject,omitempty" yaml:"clusterObject,omitempty"`
+	Conditions        []EtcdBackupCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	KubernetesVersion string                `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
 }

--- a/client/management/v3/zz_generated_restore_from_etcd_backup_input.go
+++ b/client/management/v3/zz_generated_restore_from_etcd_backup_input.go
@@ -1,10 +1,12 @@
 package client
 
 const (
-	RestoreFromEtcdBackupInputType              = "restoreFromEtcdBackupInput"
-	RestoreFromEtcdBackupInputFieldEtcdBackupID = "etcdBackupId"
+	RestoreFromEtcdBackupInputType                  = "restoreFromEtcdBackupInput"
+	RestoreFromEtcdBackupInputFieldEtcdBackupID     = "etcdBackupId"
+	RestoreFromEtcdBackupInputFieldRestoreRkeConfig = "restoreRkeConfig"
 )
 
 type RestoreFromEtcdBackupInput struct {
-	EtcdBackupID string `json:"etcdBackupId,omitempty" yaml:"etcdBackupId,omitempty"`
+	EtcdBackupID     string `json:"etcdBackupId,omitempty" yaml:"etcdBackupId,omitempty"`
+	RestoreRkeConfig string `json:"restoreRkeConfig,omitempty" yaml:"restoreRkeConfig,omitempty"`
 }


### PR DESCRIPTION
Adds two new strings to the EtcdBackup in order to grab and use them during the restore process.
https://github.com/rancher/rancher/issues/22232