### PR TITLE
Correct YAML ip_address for JSON ipAddress

### DIFF
--- a/apis/management.cattle.io/v3/rke_types.go
+++ b/apis/management.cattle.io/v3/rke_types.go
@@ -853,7 +853,7 @@ type DNSConfig struct {
 
 type Nodelocal struct {
 	// link-local IP for nodelocal DNS
-	IPAddress string `yaml:"ipaddress" json:"ipAddress,omitempy"`
+	IPAddress string `yaml:"ip_address" json:"ipAddress,omitempy"`
 	// Nodelocal DNS daemonset upgrade strategy
 	UpdateStrategy *appsv1.DaemonSetUpdateStrategy `yaml:"update_strategy" json:"updateStrategy,omitempty"`
 	// NodeSelector key pair


### PR DESCRIPTION
For RKE this works, but in Rancher this translates to `ip_address` based on `ipAddress`. To keep this consistent (and correct according to the convention), changing it.