### PR TITLE
[Master] Fix the issue that preferences show other user's name

### DIFF
--- a/apis/management.cattle.io/v3/authn_types.go
+++ b/apis/management.cattle.io/v3/authn_types.go
@@ -47,7 +47,7 @@ type User struct {
 	Password           string     `json:"password,omitempty" norman:"writeOnly,noupdate"`
 	MustChangePassword bool       `json:"mustChangePassword,omitempty"`
 	PrincipalIDs       []string   `json:"principalIds,omitempty" norman:"type=array[reference[principal]]"`
-	Me                 bool       `json:"me,omitempty"`
+	Me                 bool       `json:"me,omitempty" norman:"nocreate,noupdate"`
 	Enabled            *bool      `json:"enabled,omitempty" norman:"default=true"`
 	Spec               UserSpec   `json:"spec,omitempty"`
 	Status             UserStatus `json:"status"`


### PR DESCRIPTION
Problem:

Preferences show other user's name and username instead of the logged in user

Solution:

Users can set `Me` field of another user to true  in Rancher UI.
And it will be always true even after logout and login. 
Set Me field to nocreate and noupdate

Related PR:

https://github.com/rancher/rancher/pull/26241

Related Issue:

https://github.com/rancher/rancher/issues/14420