### PR TITLE
Add ComponentStatusesLastSync to keep record last sync time

### DIFF
--- a/apis/management.cattle.io/v3/cluster_types.go
+++ b/apis/management.cattle.io/v3/cluster_types.go
@@ -138,6 +138,7 @@ type ClusterStatus struct {
 	AgentFeatures                        map[string]bool             `json:"agentFeatures,omitempty"`
 	AuthImage                            string                      `json:"authImage"`
 	ComponentStatuses                    []ClusterComponentStatus    `json:"componentStatuses,omitempty"`
+	ComponentStatusesLastSync            *metav1.Time                `json:"componentStatusesLastSync,omitempty"`
 	APIEndpoint                          string                      `json:"apiEndpoint,omitempty"`
 	ServiceAccountToken                  string                      `json:"serviceAccountToken,omitempty"`
 	CACert                               string                      `json:"caCert,omitempty"`

--- a/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -2325,6 +2325,10 @@ func (in *ClusterStatus) DeepCopyInto(out *ClusterStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ComponentStatusesLastSync != nil {
+		in, out := &in.ComponentStatusesLastSync, &out.ComponentStatusesLastSync
+		*out = (*in).DeepCopy()
+	}
 	if in.Capacity != nil {
 		in, out := &in.Capacity, &out.Capacity
 		*out = make(corev1.ResourceList, len(*in))

--- a/client/management/v3/zz_generated_cluster.go
+++ b/client/management/v3/zz_generated_cluster.go
@@ -25,6 +25,7 @@ const (
 	ClusterFieldClusterTemplateQuestions             = "questions"
 	ClusterFieldClusterTemplateRevisionID            = "clusterTemplateRevisionId"
 	ClusterFieldComponentStatuses                    = "componentStatuses"
+	ClusterFieldComponentStatusesLastSync            = "componentStatusesLastSync"
 	ClusterFieldConditions                           = "conditions"
 	ClusterFieldCreated                              = "created"
 	ClusterFieldCreatorID                            = "creatorId"
@@ -85,6 +86,7 @@ type Cluster struct {
 	ClusterTemplateQuestions             []Question                     `json:"questions,omitempty" yaml:"questions,omitempty"`
 	ClusterTemplateRevisionID            string                         `json:"clusterTemplateRevisionId,omitempty" yaml:"clusterTemplateRevisionId,omitempty"`
 	ComponentStatuses                    []ClusterComponentStatus       `json:"componentStatuses,omitempty" yaml:"componentStatuses,omitempty"`
+	ComponentStatusesLastSync            string                         `json:"componentStatusesLastSync,omitempty" yaml:"componentStatusesLastSync,omitempty"`
 	Conditions                           []ClusterCondition             `json:"conditions,omitempty" yaml:"conditions,omitempty"`
 	Created                              string                         `json:"created,omitempty" yaml:"created,omitempty"`
 	CreatorID                            string                         `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`

--- a/client/management/v3/zz_generated_cluster_status.go
+++ b/client/management/v3/zz_generated_cluster_status.go
@@ -15,6 +15,7 @@ const (
 	ClusterStatusFieldCapacity                             = "capacity"
 	ClusterStatusFieldCertificatesExpiration               = "certificatesExpiration"
 	ClusterStatusFieldComponentStatuses                    = "componentStatuses"
+	ClusterStatusFieldComponentStatusesLastSync            = "componentStatusesLastSync"
 	ClusterStatusFieldConditions                           = "conditions"
 	ClusterStatusFieldCurrentCisRunName                    = "currentCisRunName"
 	ClusterStatusFieldDriver                               = "driver"
@@ -42,6 +43,7 @@ type ClusterStatus struct {
 	Capacity                             map[string]string           `json:"capacity,omitempty" yaml:"capacity,omitempty"`
 	CertificatesExpiration               map[string]CertExpiration   `json:"certificatesExpiration,omitempty" yaml:"certificatesExpiration,omitempty"`
 	ComponentStatuses                    []ClusterComponentStatus    `json:"componentStatuses,omitempty" yaml:"componentStatuses,omitempty"`
+	ComponentStatusesLastSync            string                      `json:"componentStatusesLastSync,omitempty" yaml:"componentStatusesLastSync,omitempty"`
 	Conditions                           []ClusterCondition          `json:"conditions,omitempty" yaml:"conditions,omitempty"`
 	CurrentCisRunName                    string                      `json:"currentCisRunName,omitempty" yaml:"currentCisRunName,omitempty"`
 	Driver                               string                      `json:"driver,omitempty" yaml:"driver,omitempty"`


### PR DESCRIPTION
Related To: https://github.com/rancher/rancher/issues/26363

This PR added new field(ComponentStatusesLastSync) which have timestamp information rancher's healthsyncer controller synced last time. 

If this time is not updated correctly, it indicate there is something wrong in rancher, and also there is possibility which cluster got bad status 