### PR TITLE
Change v2.2 k8s version to v1.14.10-rancher1-0

### DIFF
--- a/apis/management.cattle.io/v3/k8s_defaults.go
+++ b/apis/management.cattle.io/v3/k8s_defaults.go
@@ -28,7 +28,7 @@ var (
 		// Account for the fact that rke-tools image is different cross branches, and it requires using
 		// different k8s version tag
 		"v1.13.12-rancher1-1",
-		"v1.14.10-rancher1-1",
+		"v1.14.10-rancher1-0",
 		"v1.15.11-rancher1-0",
 	}
 
@@ -1541,7 +1541,7 @@ var (
 			CoreDNSAutoscaler:         m("gcr.io/google_containers/cluster-proportional-autoscaler:1.3.0"),
 		},
 		// Enabled in Rancher v2.2.11
-		"v1.14.10-rancher1-1": {
+		"v1.14.10-rancher1-0": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.3.10-rancher1"),
 			Kubernetes:                m("rancher/hyperkube:v1.14.10-rancher1"),
 			Alpine:                    m("rancher/rke-tools:v0.1.50"),


### PR DESCRIPTION
`v1.14.10-rancher1-1` was already released in v2.3 and cannot be used