### PR TITLE
[v2.2] add calicoControllers to system images for out of band k8s version 1.…

### DIFF
--- a/apis/management.cattle.io/v3/k8s_defaults.go
+++ b/apis/management.cattle.io/v3/k8s_defaults.go
@@ -1557,6 +1557,7 @@ var (
 			CalicoNode:                m("quay.io/calico/node:v3.4.0"),
 			CalicoCNI:                 m("quay.io/calico/cni:v3.4.0"),
 			CalicoCtl:                 m("quay.io/calico/ctl:v2.0.0"),
+			CalicoControllers:         m("quay.io/calico/kube-controllers:v3.4.0"),
 			CanalNode:                 m("quay.io/calico/node:v3.4.0"),
 			CanalCNI:                  m("quay.io/calico/cni:v3.4.0"),
 			CanalFlannel:              m("quay.io/coreos/flannel:v0.10.0"),


### PR DESCRIPTION
For out of band/KDM k8s versions, RKE validates against empty system images
even if it is not getting actually used by network template.