### PR TITLE
Istios UseSourceIP must be nullable or it fails LBs validation

### DIFF
--- a/apis/project.cattle.io/v3/schema/schema.go
+++ b/apis/project.cattle.io/v3/schema/schema.go
@@ -1115,6 +1115,9 @@ func istioTypes(schemas *types.Schemas) *types.Schemas {
 		MustImport(&Version, istiov1alpha3.VirtualService{}, projectOverride{}, struct {
 			Status interface{}
 		}{}).
+		MustImport(&Version, istiov1alpha3.ConsistentHashLB{}, struct {
+			UseSourceIP *bool `json:"useSourceIp,omitempty"`
+		}{}).
 		MustImport(&Version, istiov1alpha3.DestinationRule{}, projectOverride{}, struct {
 			Status interface{}
 		}{}).

--- a/client/project/v3/zz_generated_consistent_hash_lb.go
+++ b/client/project/v3/zz_generated_consistent_hash_lb.go
@@ -12,5 +12,5 @@ type ConsistentHashLB struct {
 	HTTPCookie      *HTTPCookie `json:"httpCookie,omitempty" yaml:"httpCookie,omitempty"`
 	HTTPHeaderName  string      `json:"httpHeaderName,omitempty" yaml:"httpHeaderName,omitempty"`
 	MinimumRingSize int64       `json:"minimumRingSize,omitempty" yaml:"minimumRingSize,omitempty"`
-	UseSourceIP     bool        `json:"useSourceIp,omitempty" yaml:"useSourceIp,omitempty"`
+	UseSourceIP     *bool       `json:"useSourceIp,omitempty" yaml:"useSourceIp,omitempty"`
 }


### PR DESCRIPTION
You can have only one ConsistentHashLB setting, and since useSourceIp
was not nullable and defaulting to false, it was always getting
set. Meaning setting any of the either two would fail validation.
This PR turns bool to pointer, making it nullable.
See: https://archive.istio.io/v1.4/docs/reference/config/networking/destination-rule/#LoadBalancerSettings-ConsistentHashLB

Issue: https://github.com/rancher/rancher/issues/25515

See here: /v3/project/schemas/consistentHashLB
```
"useSourceIp": {
  "create": true,
  "default": false,
  "type": "boolean",
  "update": true
}
```
=> 

```
"useSourceIp": {
  "create": true,
  "nullable": true,
  "type": "boolean",
  "update": true
}