### PR TITLE
Relax Resource Name Validation - ConfigMaps, Secrets, PVs, PVCs

### DIFF
--- a/apis/cluster.cattle.io/v3/schema/schema.go
+++ b/apis/cluster.cattle.io/v3/schema/schema.go
@@ -85,6 +85,12 @@ func persistentVolumeTypes(schemas *types.Schemas) *types.Schemas {
 			Description string `json:"description"`
 		}{}).
 		MustImportAndCustomize(&Version, v1.PersistentVolume{}, func(schema *types.Schema) {
+			schema.MustCustomizeField("name", func(field types.Field) types.Field {
+				field.Type = "hostname"
+				field.Nullable = false
+				field.Required = true
+				return field
+			})
 			schema.MustCustomizeField("volumeMode", func(field types.Field) types.Field {
 				field.Update = false
 				return field

--- a/apis/management.cattle.io/v3/schema/schema.go
+++ b/apis/management.cattle.io/v3/schema/schema.go
@@ -98,6 +98,12 @@ func mgmtSecretTypes(schemas *types.Schemas) *types.Schemas {
 		schema.PluralName = "managementSecrets"
 		schema.CodeName = "ManagementSecret"
 		schema.CodeNamePlural = "ManagementSecrets"
+		schema.MustCustomizeField("name", func(field types.Field) types.Field {
+			field.Type = "hostname"
+			field.Nullable = false
+			field.Required = true
+			return field
+		})
 	})
 }
 

--- a/apis/project.cattle.io/v3/schema/schema.go
+++ b/apis/project.cattle.io/v3/schema/schema.go
@@ -53,7 +53,14 @@ var (
 )
 
 func configMapTypes(schemas *types.Schemas) *types.Schemas {
-	return schemas.MustImport(&Version, v1.ConfigMap{}, projectOverride{})
+	return schemas.MustImportAndCustomize(&Version, v1.ConfigMap{}, func(schema *types.Schema) {
+		schema.MustCustomizeField("name", func(field types.Field) types.Field {
+			field.Type = "hostname"
+			field.Nullable = false
+			field.Required = true
+			return field
+		})
+	}, projectOverride{})
 }
 
 type DeploymentConfig struct {
@@ -775,7 +782,14 @@ func volumeTypes(schemas *types.Schemas) *types.Schemas {
 			VolumeName       string   `json:"volumeName,omitempty" norman:"type=reference[/v3/cluster/persistentVolume]"`
 			StorageClassName *string  `json:"storageClassName,omitempty" norman:"type=reference[/v3/cluster/storageClass]"`
 		}{}).
-		MustImport(&Version, v1.PersistentVolumeClaim{}, projectOverride{})
+		MustImportAndCustomize(&Version, v1.PersistentVolumeClaim{}, func(schema *types.Schema) {
+			schema.MustCustomizeField("name", func(field types.Field) types.Field {
+				field.Type = "hostname"
+				field.Nullable = false
+				field.Required = true
+				return field
+			})
+		}, projectOverride{})
 }
 
 func appTypes(schema *types.Schemas) *types.Schemas {

--- a/apis/project.cattle.io/v3/schema/schema_secrets.go
+++ b/apis/project.cattle.io/v3/schema/schema_secrets.go
@@ -219,6 +219,12 @@ func secretTypes(schemas *types.Schemas) *types.Schemas {
 				}
 				return f
 			})
+			schema.MustCustomizeField("name", func(field types.Field) types.Field {
+				field.Type = "hostname"
+				field.Nullable = false
+				field.Required = true
+				return field
+			})
 		}, projectOverride{}, struct {
 			Description string `json:"description"`
 		}{}).


### PR DESCRIPTION
Issue: 
- rancher/rancher#25955

This addresses some of the validation differences between Rancher and Kubernetes. The names for ConfigMaps, Secrets, PersistentVolumes, and PersistentVolumeClaims resources are all validated as DNS Subdomain by Kubernetes; these changes allow for these resources to be created with DNS Subdomain compliant names through the Rancher UI. 

For example, before these changes you could not create a secret with name: `my.secret` (satisfies DNS Subdomain regexp but not DNS Label regexp), which is a valid secret name in Kubernetes. Now you are able to create `my.secret`. The rest of the types are similar. 

I have validated these changes in `rancher/rancher:release/v2.4-HEAD` and `master-HEAD`.

NOTE: No name validation changes were made for Workloads as this would require us to change the naming strategy for the containers inside the pods that workloads create. So, as of this PR we still have stricter validation than Kubernetes for the `name` field of: DaemonSet, Deployment, ReplicaSet, StatefulSet, CronJob, and Job resources. If we did want to relax Workload name validation, we could make further modifications to types and add a method `setContainerName` to the [workload store](https://github.com/rancher/rancher/blob/master/pkg/api/store/workload/workload_store.go#L72), which would transform the container name to a valid DNS Label in the case the Workload and thus the container was named as a DNS Subdomain. See the issue comments for more details regarding this. 