### PR TITLE
Fix node.status.capacity.cpu conversion issue

### DIFF
--- a/mapper/os_info.go
+++ b/mapper/os_info.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rancher/norman/types"
 	"github.com/rancher/norman/types/convert"
 	"github.com/rancher/norman/types/values"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 type OSInfo struct {
@@ -15,16 +16,17 @@ func (o OSInfo) FromInternal(data map[string]interface{}) {
 	if data == nil {
 		return
 	}
-	cpuInfo := map[string]interface{}{
-		"count": values.GetValueN(data, "capacity", "cpu"),
+
+	cpuInfo := map[string]interface{}{}
+	cpuNum, err := resource.ParseQuantity(convert.ToString(values.GetValueN(data, "capacity", "cpu")))
+	if err == nil {
+		cpuInfo["count"] = cpuNum.Value()
 	}
 
-	kib := strings.TrimSuffix(convert.ToString(values.GetValueN(data, "capacity", "memory")), "Ki")
 	memoryInfo := map[string]interface{}{}
-
-	kibNum, err := convert.ToNumber(kib)
+	kibNum, err := resource.ParseQuantity(convert.ToString(values.GetValueN(data, "capacity", "memory")))
 	if err == nil {
-		memoryInfo["memTotalKiB"] = kibNum
+		memoryInfo["memTotalKiB"] = kibNum.Value() / 1024
 	}
 
 	osInfo := map[string]interface{}{

--- a/mapper/os_info_test.go
+++ b/mapper/os_info_test.go
@@ -1,0 +1,73 @@
+package mapper
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_OsInfo(t *testing.T) {
+	mapper := OSInfo{}
+
+	tests := []struct {
+		internal map[string]interface{}
+		wantInfo map[string]interface{}
+	}{
+		{
+			internal: map[string]interface{}{
+				"capacity": map[string]interface{}{
+					"cpu":    "2",
+					"memory": "123456Ki",
+				},
+			},
+			wantInfo: map[string]interface{}{
+				"cpu": map[string]interface{}{
+					"count": int64(2),
+				},
+				"memory": map[string]interface{}{
+					"memTotalKiB": int64(123456),
+				},
+				"os": map[string]interface{}{
+					"dockerVersion":   "",
+					"kernelVersion":   nil,
+					"operatingSystem": nil,
+				},
+				"kubernetes": map[string]interface{}{
+					"kubeletVersion":   nil,
+					"kubeProxyVersion": nil,
+				},
+			},
+		},
+		{
+			internal: map[string]interface{}{
+				"capacity": map[string]interface{}{
+					"cpu":    "1M",
+					"memory": "123456Ti",
+				},
+			},
+			wantInfo: map[string]interface{}{
+				"cpu": map[string]interface{}{
+					"count": int64(1000000),
+				},
+				"memory": map[string]interface{}{
+					"memTotalKiB": int64(132559870623744),
+				},
+				"os": map[string]interface{}{
+					"dockerVersion":   "",
+					"kernelVersion":   nil,
+					"operatingSystem": nil,
+				},
+				"kubernetes": map[string]interface{}{
+					"kubeletVersion":   nil,
+					"kubeProxyVersion": nil,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		mapper.FromInternal(tt.internal)
+		if !reflect.DeepEqual(tt.wantInfo, tt.internal["info"]) {
+			t.Fatal("os info does not match after mapping")
+		}
+	}
+}


### PR DESCRIPTION
**Problem:**

Aliyun virtual kubelet node cannot be displayed in the Rancher UI because the `node.status.capacity.cpu` of the virtual kubelet is `1M`, which is not a number.

`1000m`, `1`, `100`, `1M` are all valid values for `node.status.capacity.cpu` field in Kubernetes.

However, in Rancher types, the filed is `int`, and we will not convert it to number if they are not `int` in rancher/types.

**Solution:**

So we need to handle other cases

**Related Issue:**

https://github.com/rancher/rancher/issues/26226

**Related PR:**

https://github.com/rancher/rancher/pull/27523
