### PR TITLE
remove -l from go imports

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -102,7 +102,7 @@ func generateComposeType(baseCompose string, projectSchemas *types.Schemas, mana
 }
 
 func gofmt(workDir, pkg string) error {
-	cmd := exec.Command("goimports", "-w", "-l", "./"+pkg)
+	cmd := exec.Command("goimports", "-w", pkg)
 	fmt.Println(cmd.Args)
 	cmd.Dir = workDir
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Per this recent change to goimports https://go-review.googlesource.com/c/tools/+/234484 `-l` now returns an exit code of 1 and generation will fail due to panic