### PR TITLE
Revert minio version update

### DIFF
--- a/apis/management.cattle.io/v3/tools_system_images.go
+++ b/apis/management.cattle.io/v3/tools_system_images.go
@@ -17,7 +17,7 @@ var (
 			JenkinsJnlp:   m("jenkins/jnlp-slave:3.35-4"),
 			AlpineGit:     m("rancher/pipeline-tools:v0.1.14"),
 			PluginsDocker: m("plugins/docker:18.09"),
-			Minio:         m("minio/minio:RELEASE.2020-07-13T18-09-56Z"),
+			Minio:         m("minio/minio:RELEASE.2019-09-25T18-25-51Z"),
 			Registry:      m("registry:2"),
 			RegistryProxy: m("rancher/pipeline-tools:v0.1.14"),
 			KubeApply:     m("rancher/pipeline-tools:v0.1.14"),


### PR DESCRIPTION
**Problem:** 
When the minio workload is deployed during a pipeline run, it will
fall into a crashloop or restart multiple times causing the pipeline
to fail.

**Related Issues:** 
https://github.com/rancher/rancher/issues/28025
https://github.com/rancher/rancher/issues/28031