### PR TITLE
Add a CanalControllers image field for Canal

### DIFF
--- a/apis/management.cattle.io/v3/rke_types.go
+++ b/apis/management.cattle.io/v3/rke_types.go
@@ -150,6 +150,8 @@ type RKESystemImages struct {
 	CanalNode string `yaml:"canal_node" json:"canalNode,omitempty"`
 	// Canal CNI image
 	CanalCNI string `yaml:"canal_cni" json:"canalCni,omitempty"`
+	// Canal Controllers Image needed for Calico/Canal v3.14.0+
+	CanalControllers string `yaml:"canal_controllers" json:"canalControllers,omitempty"`
 	//CanalFlannel image
 	CanalFlannel string `yaml:"canal_flannel" json:"canalFlannel,omitempty"`
 	//CanalFlexVol image

--- a/client/management/v3/zz_generated_rke_system_images.go
+++ b/client/management/v3/zz_generated_rke_system_images.go
@@ -9,6 +9,7 @@ const (
 	RKESystemImagesFieldCalicoFlexVol             = "calicoFlexVol"
 	RKESystemImagesFieldCalicoNode                = "calicoNode"
 	RKESystemImagesFieldCanalCNI                  = "canalCni"
+	RKESystemImagesFieldCanalControllers          = "canalControllers"
 	RKESystemImagesFieldCanalFlannel              = "canalFlannel"
 	RKESystemImagesFieldCanalFlexVol              = "canalFlexVol"
 	RKESystemImagesFieldCanalNode                 = "canalNode"
@@ -43,6 +44,7 @@ type RKESystemImages struct {
 	CalicoFlexVol             string `json:"calicoFlexVol,omitempty" yaml:"calicoFlexVol,omitempty"`
 	CalicoNode                string `json:"calicoNode,omitempty" yaml:"calicoNode,omitempty"`
 	CanalCNI                  string `json:"canalCni,omitempty" yaml:"canalCni,omitempty"`
+	CanalControllers          string `json:"canalControllers,omitempty" yaml:"canalControllers,omitempty"`
 	CanalFlannel              string `json:"canalFlannel,omitempty" yaml:"canalFlannel,omitempty"`
 	CanalFlexVol              string `json:"canalFlexVol,omitempty" yaml:"canalFlexVol,omitempty"`
 	CanalNode                 string `json:"canalNode,omitempty" yaml:"canalNode,omitempty"`


### PR DESCRIPTION
Add a CanalControllers image field for Canal as it is needed for Calico/Canal versions higher than v3.14.0

We are bumping Canal to v3.16.0 which requires a calico-controller to update/modify HostEndpoints.

https://github.com/rancher/rancher/issues/26717

Signed-off-by: Chris Kim <oats87g@gmail.com>