### PR TITLE
[2.4] update default for ignoreDaemonSets

### DIFF
--- a/apis/management.cattle.io/v3/schema/schema.go
+++ b/apis/management.cattle.io/v3/schema/schema.go
@@ -379,7 +379,11 @@ func nodeTypes(schemas *types.Schemas) *types.Schemas {
 				Update:   false,
 			}
 		}).
-		MustImport(&Version, v3.NodeDrainInput{}).
+		MustImportAndCustomize(&Version, v3.NodeDrainInput{}, func(schema *types.Schema) {
+			dsField := schema.ResourceFields["ignoreDaemonSets"]
+			test := true
+			dsField.Default = &test
+		}).
 		MustImportAndCustomize(&Version, v3.Node{}, func(schema *types.Schema) {
 			labelField := schema.ResourceFields["labels"]
 			labelField.Create = true


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/28998

ignoreDaemonSets is a *bool, so it's null if user doesn't pick a value and panics. Setting &true as default. 