### PR TITLE
 Add starttls option for ldap and AD

### DIFF
--- a/apis/management.cattle.io/v3/authn_types.go
+++ b/apis/management.cattle.io/v3/authn_types.go
@@ -239,6 +239,7 @@ type ActiveDirectoryConfig struct {
 	Servers                      []string `json:"servers,omitempty"                     norman:"type=array[string],required"`
 	Port                         int64    `json:"port,omitempty"                        norman:"default=389"`
 	TLS                          bool     `json:"tls,omitempty"                         norman:"default=false"`
+	StartTLS                     bool     `json:"starttls,omitempty"                    norman:"default=false"`
 	Certificate                  string   `json:"certificate,omitempty"`
 	DefaultLoginDomain           string   `json:"defaultLoginDomain,omitempty"`
 	ServiceAccountUsername       string   `json:"serviceAccountUsername,omitempty"      norman:"required"`
@@ -274,6 +275,7 @@ type LdapFields struct {
 	Servers                         []string `json:"servers,omitempty"                         norman:"type=array[string],notnullable,required"`
 	Port                            int64    `json:"port,omitempty"                            norman:"default=389,notnullable,required"`
 	TLS                             bool     `json:"tls,omitempty"                             norman:"default=false,notnullable,required"`
+	StartTLS                        bool     `json:"starttls,omitempty"                        norman:"default=false"`
 	Certificate                     string   `json:"certificate,omitempty"`
 	ServiceAccountDistinguishedName string   `json:"serviceAccountDistinguishedName,omitempty" norman:"required"`
 	ServiceAccountPassword          string   `json:"serviceAccountPassword,omitempty"          norman:"type=password,required"`

--- a/client/management/v3/zz_generated_active_directory_config.go
+++ b/client/management/v3/zz_generated_active_directory_config.go
@@ -28,6 +28,7 @@ const (
 	ActiveDirectoryConfigFieldServers                      = "servers"
 	ActiveDirectoryConfigFieldServiceAccountPassword       = "serviceAccountPassword"
 	ActiveDirectoryConfigFieldServiceAccountUsername       = "serviceAccountUsername"
+	ActiveDirectoryConfigFieldStartTLS                     = "starttls"
 	ActiveDirectoryConfigFieldTLS                          = "tls"
 	ActiveDirectoryConfigFieldType                         = "type"
 	ActiveDirectoryConfigFieldUUID                         = "uuid"
@@ -68,6 +69,7 @@ type ActiveDirectoryConfig struct {
 	Servers                      []string          `json:"servers,omitempty" yaml:"servers,omitempty"`
 	ServiceAccountPassword       string            `json:"serviceAccountPassword,omitempty" yaml:"serviceAccountPassword,omitempty"`
 	ServiceAccountUsername       string            `json:"serviceAccountUsername,omitempty" yaml:"serviceAccountUsername,omitempty"`
+	StartTLS                     bool              `json:"starttls,omitempty" yaml:"starttls,omitempty"`
 	TLS                          bool              `json:"tls,omitempty" yaml:"tls,omitempty"`
 	Type                         string            `json:"type,omitempty" yaml:"type,omitempty"`
 	UUID                         string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`

--- a/client/management/v3/zz_generated_free_ipa_config.go
+++ b/client/management/v3/zz_generated_free_ipa_config.go
@@ -26,6 +26,7 @@ const (
 	FreeIpaConfigFieldServers                         = "servers"
 	FreeIpaConfigFieldServiceAccountDistinguishedName = "serviceAccountDistinguishedName"
 	FreeIpaConfigFieldServiceAccountPassword          = "serviceAccountPassword"
+	FreeIpaConfigFieldStartTLS                        = "starttls"
 	FreeIpaConfigFieldTLS                             = "tls"
 	FreeIpaConfigFieldType                            = "type"
 	FreeIpaConfigFieldUUID                            = "uuid"
@@ -65,6 +66,7 @@ type FreeIpaConfig struct {
 	Servers                         []string          `json:"servers,omitempty" yaml:"servers,omitempty"`
 	ServiceAccountDistinguishedName string            `json:"serviceAccountDistinguishedName,omitempty" yaml:"serviceAccountDistinguishedName,omitempty"`
 	ServiceAccountPassword          string            `json:"serviceAccountPassword,omitempty" yaml:"serviceAccountPassword,omitempty"`
+	StartTLS                        bool              `json:"starttls,omitempty" yaml:"starttls,omitempty"`
 	TLS                             bool              `json:"tls,omitempty" yaml:"tls,omitempty"`
 	Type                            string            `json:"type,omitempty" yaml:"type,omitempty"`
 	UUID                            string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`

--- a/client/management/v3/zz_generated_ldap_config.go
+++ b/client/management/v3/zz_generated_ldap_config.go
@@ -31,6 +31,7 @@ const (
 	LdapConfigFieldServers                         = "servers"
 	LdapConfigFieldServiceAccountDistinguishedName = "serviceAccountDistinguishedName"
 	LdapConfigFieldServiceAccountPassword          = "serviceAccountPassword"
+	LdapConfigFieldStartTLS                        = "starttls"
 	LdapConfigFieldTLS                             = "tls"
 	LdapConfigFieldType                            = "type"
 	LdapConfigFieldUUID                            = "uuid"
@@ -72,6 +73,7 @@ type LdapConfig struct {
 	Servers                         []string          `json:"servers,omitempty" yaml:"servers,omitempty"`
 	ServiceAccountDistinguishedName string            `json:"serviceAccountDistinguishedName,omitempty" yaml:"serviceAccountDistinguishedName,omitempty"`
 	ServiceAccountPassword          string            `json:"serviceAccountPassword,omitempty" yaml:"serviceAccountPassword,omitempty"`
+	StartTLS                        bool              `json:"starttls,omitempty" yaml:"starttls,omitempty"`
 	TLS                             bool              `json:"tls,omitempty" yaml:"tls,omitempty"`
 	Type                            string            `json:"type,omitempty" yaml:"type,omitempty"`
 	UUID                            string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`

--- a/client/management/v3/zz_generated_ldap_fields.go
+++ b/client/management/v3/zz_generated_ldap_fields.go
@@ -17,6 +17,7 @@ const (
 	LdapFieldsFieldServers                         = "servers"
 	LdapFieldsFieldServiceAccountDistinguishedName = "serviceAccountDistinguishedName"
 	LdapFieldsFieldServiceAccountPassword          = "serviceAccountPassword"
+	LdapFieldsFieldStartTLS                        = "starttls"
 	LdapFieldsFieldTLS                             = "tls"
 	LdapFieldsFieldUserDisabledBitMask             = "userDisabledBitMask"
 	LdapFieldsFieldUserEnabledAttribute            = "userEnabledAttribute"
@@ -45,6 +46,7 @@ type LdapFields struct {
 	Servers                         []string `json:"servers,omitempty" yaml:"servers,omitempty"`
 	ServiceAccountDistinguishedName string   `json:"serviceAccountDistinguishedName,omitempty" yaml:"serviceAccountDistinguishedName,omitempty"`
 	ServiceAccountPassword          string   `json:"serviceAccountPassword,omitempty" yaml:"serviceAccountPassword,omitempty"`
+	StartTLS                        bool     `json:"starttls,omitempty" yaml:"starttls,omitempty"`
 	TLS                             bool     `json:"tls,omitempty" yaml:"tls,omitempty"`
 	UserDisabledBitMask             int64    `json:"userDisabledBitMask,omitempty" yaml:"userDisabledBitMask,omitempty"`
 	UserEnabledAttribute            string   `json:"userEnabledAttribute,omitempty" yaml:"userEnabledAttribute,omitempty"`

--- a/client/management/v3/zz_generated_open_ldap_config.go
+++ b/client/management/v3/zz_generated_open_ldap_config.go
@@ -27,6 +27,7 @@ const (
 	OpenLdapConfigFieldServers                         = "servers"
 	OpenLdapConfigFieldServiceAccountDistinguishedName = "serviceAccountDistinguishedName"
 	OpenLdapConfigFieldServiceAccountPassword          = "serviceAccountPassword"
+	OpenLdapConfigFieldStartTLS                        = "starttls"
 	OpenLdapConfigFieldTLS                             = "tls"
 	OpenLdapConfigFieldType                            = "type"
 	OpenLdapConfigFieldUUID                            = "uuid"
@@ -67,6 +68,7 @@ type OpenLdapConfig struct {
 	Servers                         []string          `json:"servers,omitempty" yaml:"servers,omitempty"`
 	ServiceAccountDistinguishedName string            `json:"serviceAccountDistinguishedName,omitempty" yaml:"serviceAccountDistinguishedName,omitempty"`
 	ServiceAccountPassword          string            `json:"serviceAccountPassword,omitempty" yaml:"serviceAccountPassword,omitempty"`
+	StartTLS                        bool              `json:"starttls,omitempty" yaml:"starttls,omitempty"`
 	TLS                             bool              `json:"tls,omitempty" yaml:"tls,omitempty"`
 	Type                            string            `json:"type,omitempty" yaml:"type,omitempty"`
 	UUID                            string            `json:"uuid,omitempty" yaml:"uuid,omitempty"`


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/29810

Backport PR for https://github.com/rancher/rancher/pull/30267

Since Rancher 2.4 branch vendors in rancher/types, this PR only contains the changes for adding the new field from the original PR https://github.com/rancher/rancher/pull/30267 
The changes are from [this](https://github.com/rancher/rancher/pull/30267/files#diff-c9ef311bd9802ccb80d18f2ad24ba6537c70214f4becac6770e52f10e40f4723) file